### PR TITLE
TargetPlatformIdentifier windows removed

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,3 +29,9 @@ jobs:
 
       - name: Test (Release)
         run: dotnet test -c Release --no-build --verbosity normal
+
+      - name: Nuget pack library
+        run: dotnet pack -c Release src/dscom/dscom.csproj
+
+      - name: Nuget pack tool
+        run: dotnet pack -c Release src/dscom.client/dscom.client.csproj

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,8 +6,8 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/src/dscom.client/bin/Debug/net6.0-windows/dscom.dll",
-            "args": ["tlbexport", "/verbose", "${workspaceFolder}/src/dscom.demo/assembly1/bin/Debug/net6.0-windows/dSPACE.Runtime.InteropServices.DemoAssembly1.dll", "/out:${workspaceFolder}/src/dscom.demo/assembly1/bin/Debug/net6.0-windows/dSPACE.Runtime.InteropServices.DemoAssembly1.tlb"],
+            "program": "${workspaceFolder}/src/dscom.client/bin/Debug/net6.0/dscom.dll",
+            "args": ["tlbexport", "/verbose", "${workspaceFolder}/src/dscom.demo/assembly1/bin/Debug/net6.0/dSPACE.Runtime.InteropServices.DemoAssembly1.dll", "/out:${workspaceFolder}/src/dscom.demo/assembly1/bin/Debug/net6.0/dSPACE.Runtime.InteropServices.DemoAssembly1.tlb"],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,
             "console": "internalConsole"
@@ -17,8 +17,8 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/src/dscom.client/bin/Debug/net6.0-windows/dscom.dll",
-            "args": ["tlbdump", "${workspaceFolder}/src/dscom.demo/assembly1/bin/Debug/net6.0-windows/dSPACE.Runtime.InteropServices.DemoAssembly1.tlb", "/out:${workspaceFolder}/src/dscom.demo/assembly1/bin/Debug/net6.0-windows/dSPACE.Runtime.InteropServices.DemoAssembly1.yaml", "/tlbrefpath:${workspaceFolder}/src/dscom.demo/assembly1/bin/Debug/net6.0-windows/", "/filterregex=\\.file\\="],
+            "program": "${workspaceFolder}/src/dscom.client/bin/Debug/net6.0/dscom.dll",
+            "args": ["tlbdump", "${workspaceFolder}/src/dscom.demo/assembly1/bin/Debug/net6.0/dSPACE.Runtime.InteropServices.DemoAssembly1.tlb", "/out:${workspaceFolder}/src/dscom.demo/assembly1/bin/Debug/net6.0/dSPACE.Runtime.InteropServices.DemoAssembly1.yaml", "/tlbrefpath:${workspaceFolder}/src/dscom.demo/assembly1/bin/Debug/net6.0/", "/filterregex=\\.file\\="],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,
             "console": "internalConsole"

--- a/scripts/demo.bat
+++ b/scripts/demo.bat
@@ -4,24 +4,24 @@ SET workspace=%~dp0..\
 @REM set filterregex=--filterregex \.file\= --filterregex \.attributes\.guid\= --filterregex numberOfImplementedInterfaces --filterregex implementedInterfaces
 set filterregex=
 
-SET net60dll=%workspace%src\dscom.demo\assembly1\bin\Release\net6.0-windows\dSPACE.Runtime.InteropServices.DemoAssembly1.dll
-SET net48dll=%workspace%src\dscom.demo\assembly1\bin\Release\net48-windows\dSPACE.Runtime.InteropServices.DemoAssembly1.dll
+SET net60dll=%workspace%src\dscom.demo\assembly1\bin\Release\net6.0\dSPACE.Runtime.InteropServices.DemoAssembly1.dll
+SET net48dll=%workspace%src\dscom.demo\assembly1\bin\Release\net48\dSPACE.Runtime.InteropServices.DemoAssembly1.dll
 
-del %workspace%src\dscom.demo\assembly1\bin\Release\net48-windows\*.tlb 
-del %workspace%src\dscom.demo\assembly1\bin\Release\net6.0-windows\*.tlb 
-del %workspace%src\dscom.demo\assembly1\bin\Release\net6.0-windows\*.yaml
-del %workspace%src\dscom.demo\assembly1\bin\Release\net48-windows\*.yaml
+del %workspace%src\dscom.demo\assembly1\bin\Release\net48\*.tlb 
+del %workspace%src\dscom.demo\assembly1\bin\Release\net6.0\*.tlb 
+del %workspace%src\dscom.demo\assembly1\bin\Release\net6.0\*.yaml
+del %workspace%src\dscom.demo\assembly1\bin\Release\net48\*.yaml
 
 dotnet build -c Release "%workspace%dscom.sln"
 IF ERRORLEVEL 1 goto error
 
 @REM dscom
 echo ############## dscom.exe tlbexport
-%workspace%src\dscom.client\bin\Release\net6.0-windows\dscom.exe tlbexport /verbose "%net60dll%" "/out:%net60dll%.tlb"
+%workspace%src\dscom.client\bin\Release\net6.0\dscom.exe tlbexport /verbose "%net60dll%" "/out:%net60dll%.tlb"
 IF ERRORLEVEL 1 goto error
 
 echo ############## dscom.exe tlbdump
-%workspace%src\dscom.client\bin\Release\net6.0-windows\dscom.exe tlbdump %filterregex% "/tlbrefpath:%net60dll%.tlb/.." "%net60dll%.tlb" "/out:%net60dll%.yaml"
+%workspace%src\dscom.client\bin\Release\net6.0\dscom.exe tlbdump %filterregex% "/tlbrefpath:%net60dll%.tlb/.." "%net60dll%.tlb" "/out:%net60dll%.yaml"
 IF ERRORLEVEL 1 goto error
 
 WHERE tlbexp
@@ -43,7 +43,7 @@ tlbexp /win64 /verbose "%net48dll%" "/out:%net48dll%.tlb"
 IF ERRORLEVEL 1 goto error
 
 echo ############## dscom.exe tlbdump
-%workspace%src\dscom.client\bin\Release\net6.0-windows\dscom.exe tlbdump %filterregex% "/tlbrefpath:%net48dll%.tlb/.." "%net48dll%.tlb" "/out:%net48dll%.yaml"
+%workspace%src\dscom.client\bin\Release\net6.0\dscom.exe tlbdump %filterregex% "/tlbrefpath:%net48dll%.tlb/.." "%net48dll%.tlb" "/out:%net48dll%.yaml"
 IF ERRORLEVEL 1 goto error
 
 WHERE code

--- a/scripts/test.coverage.bat
+++ b/scripts/test.coverage.bat
@@ -7,5 +7,5 @@ IF NOT EXIST %TEST_RESULTS% (
     mkdir %TEST_RESULTS%
 )
 
-dotnet test -f net6.0-windows -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=%TEST_RESULTS%\lcov.info --logger "trx;LogFileName=%TEST_RESULTS%\results.xml" %PWD%..\dscom.sln 
+dotnet test -f net6.0 -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=%TEST_RESULTS%\lcov.info --logger "trx;LogFileName=%TEST_RESULTS%\results.xml" %PWD%..\dscom.sln 
 COPY %TEST_RESULTS%\lcov.net6.0.info %TEST_RESULTS%\lcov.info

--- a/scripts/test.coverage.report.bat
+++ b/scripts/test.coverage.report.bat
@@ -9,5 +9,5 @@ IF NOT EXIST %TEST_RESULTS% (
 
 dotnet tool install -g dotnet-reportgenerator-globaltool
 
-dotnet test  -f net6.0-windows -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput="%TEST_RESULTS%\\"  %PWD%..\dscom.sln 
-reportgenerator -reports:"%TEST_RESULTS%\coverage.net6.0-windows.cobertura.xml" -targetdir:"%TEST_RESULTS%\report" -reporttypes:Html
+dotnet test  -f net6.0 -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput="%TEST_RESULTS%\\"  %PWD%..\dscom.sln 
+reportgenerator -reports:"%TEST_RESULTS%\coverage.net6.0.cobertura.xml" -targetdir:"%TEST_RESULTS%\report" -reporttypes:Html

--- a/scripts/test.watch.bat
+++ b/scripts/test.watch.bat
@@ -2,4 +2,4 @@
 
 SET PWD=%~dp0
 
-dotnet watch test -f net6.0-windows -c Release --project %PWD%..\src\dscom.test\dscom.test.csproj
+dotnet watch test -f net6.0 -c Release --project %PWD%..\src\dscom.test\dscom.test.csproj

--- a/src/dscom.client/dscom.client.csproj
+++ b/src/dscom.client/dscom.client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>dscom</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/dscom.demo/assembly1/assembly1.csproj
+++ b/src/dscom.demo/assembly1/assembly1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;net48-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/dscom.demo/assembly2/assembly2.csproj
+++ b/src/dscom.demo/assembly2/assembly2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;net48-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/dscom.demo/assembly3/assembly3.csproj
+++ b/src/dscom.demo/assembly3/assembly3.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;net48-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/dscom.test/dscom.test.csproj
+++ b/src/dscom.test/dscom.test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;net48-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
@@ -38,7 +38,7 @@
     <ProjectReference Include="..\dscom\dscom.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net48-windows'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <Compile Remove="tests\CLITest\**" />
   </ItemGroup>
 

--- a/src/dscom.test/tests/CLITest/CompileReleaseFixture.cs
+++ b/src/dscom.test/tests/CLITest/CompileReleaseFixture.cs
@@ -43,11 +43,11 @@ public class CompileReleaseFixture
 #endif
 
         // Path to descom.exe
-        DSComPath = Path.Combine(Workdir, "src", "dscom.client", "bin", configuration, "net6.0-windows", "dscom.exe");
+        DSComPath = Path.Combine(Workdir, "src", "dscom.client", "bin", configuration, "net6.0", "dscom.exe");
 
         // Path to dscom.demo assemblies
-        DemoProjectAssembly1Path = Path.Combine(Workdir, "src", "dscom.demo", "assembly1", "bin", configuration, "net6.0-windows", "dSPACE.Runtime.InteropServices.DemoAssembly1.dll");
-        DemoProjectAssembly2Path = Path.Combine(Workdir, "src", "dscom.demo", "assembly2", "bin", configuration, "net6.0-windows", "dSPACE.Runtime.InteropServices.DemoAssembly2.dll");
-        DemoProjectAssembly3Path = Path.Combine(Workdir, "src", "dscom.demo", "assembly3", "bin", configuration, "net6.0-windows", "dSPACE.Runtime.InteropServices.DemoAssembly3.dll");
+        DemoProjectAssembly1Path = Path.Combine(Workdir, "src", "dscom.demo", "assembly1", "bin", configuration, "net6.0", "dSPACE.Runtime.InteropServices.DemoAssembly1.dll");
+        DemoProjectAssembly2Path = Path.Combine(Workdir, "src", "dscom.demo", "assembly2", "bin", configuration, "net6.0", "dSPACE.Runtime.InteropServices.DemoAssembly2.dll");
+        DemoProjectAssembly3Path = Path.Combine(Workdir, "src", "dscom.demo", "assembly3", "bin", configuration, "net6.0", "dSPACE.Runtime.InteropServices.DemoAssembly3.dll");
     }
 }

--- a/src/dscom/dscom.csproj
+++ b/src/dscom/dscom.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>dSPACE.Runtime.InteropServices</AssemblyName>
-    <TargetFrameworks>net6.0-windows;net48-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <Platforms>x64</Platforms>
     <LangVersion>10.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
NETSDK1146

PackAsTool does not support TargetPlatformIdentifier being set. For example, TargetFramework cannot be net5.0-windows, only net5.0. PackAsTool also does not support UseWPF or UseWindowsForms when targeting .NET 5 and higher.

dotnet pack as CI step added
