### PR TITLE
fix: Bugfix/50 warning regarding type substitution

### DIFF
--- a/src/dscom.demo/assembly1/IDemoInterfaceWithMarshalAs.cs
+++ b/src/dscom.demo/assembly1/IDemoInterfaceWithMarshalAs.cs
@@ -783,9 +783,13 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Decimal_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] decimal Param1);
     #endregion
 
-    #region Marshal the IList values in return and parameters
+    #region Marshal the IList in return values 
     [return: MarshalAs(UnmanagedType.IUnknown)]
     IList TestMethod_ReturnValue_System_IList_IUnknown();
+
+    #endregion
+
+    #region IList parameter
     void TestMethod_System_IList_Bool([MarshalAs(UnmanagedType.Bool)] IList Param1);
     void TestMethod_System_IList_VariantBool([MarshalAs(UnmanagedType.VariantBool)] IList Param1);
     void TestMethod_System_IList_I1([MarshalAs(UnmanagedType.I1)] IList Param1);

--- a/src/dscom.demo/assembly1/IDemoInterfaceWithMarshalAs.cs
+++ b/src/dscom.demo/assembly1/IDemoInterfaceWithMarshalAs.cs
@@ -783,8 +783,10 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Decimal_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] decimal Param1);
     #endregion
 
-    #region Marshal the return value 
+    #region Marshal the IList values in return and parameters
     [return: MarshalAs(UnmanagedType.IUnknown)]
     IList TestMethod_ReturnValue_System_IList_IUnknown();
+    void TestMethod_System_IList_SaveArray([MarshalAs(UnmanagedType.SafeArray)] IList elements);
+
     #endregion
 }

--- a/src/dscom.demo/assembly1/IDemoInterfaceWithMarshalAs.cs
+++ b/src/dscom.demo/assembly1/IDemoInterfaceWithMarshalAs.cs
@@ -23,6 +23,7 @@ namespace dSPACE.Runtime.InteropServices.DemoAssembly1;
 [InterfaceType(ComInterfaceType.InterfaceIsIDispatch)]
 public interface IDemoInterfaceWithMarshalAs
 {
+    #region boolean
     void TestMethod_System_Boolean_Bool([MarshalAs(UnmanagedType.Bool)] bool Param1);
     void TestMethod_System_Boolean_U8([MarshalAs(UnmanagedType.U8)] bool Param1);
     void TestMethod_System_Boolean_VariantBool([MarshalAs(UnmanagedType.VariantBool)] bool Param1);
@@ -58,6 +59,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Boolean_IInspectable([MarshalAs(UnmanagedType.IInspectable)] bool Param1);
     void TestMethod_System_Boolean_HString([MarshalAs(UnmanagedType.HString)] bool Param1);
     void TestMethod_System_Boolean_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] bool Param1);
+    #endregion
+
+    #region byte
     void TestMethod_System_Byte_Bool([MarshalAs(UnmanagedType.Bool)] byte Param1);
     void TestMethod_System_Byte_VariantBool([MarshalAs(UnmanagedType.VariantBool)] byte Param1);
     void TestMethod_System_Byte_I1([MarshalAs(UnmanagedType.I1)] byte Param1);
@@ -93,6 +97,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Byte_IInspectable([MarshalAs(UnmanagedType.IInspectable)] byte Param1);
     void TestMethod_System_Byte_HString([MarshalAs(UnmanagedType.HString)] byte Param1);
     void TestMethod_System_Byte_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] byte Param1);
+    #endregion
+
+    #region sbyte
     void TestMethod_System_SByte_Bool([MarshalAs(UnmanagedType.Bool)] sbyte Param1);
     void TestMethod_System_SByte_VariantBool([MarshalAs(UnmanagedType.VariantBool)] sbyte Param1);
     void TestMethod_System_SByte_I1([MarshalAs(UnmanagedType.I1)] sbyte Param1);
@@ -128,6 +135,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_SByte_IInspectable([MarshalAs(UnmanagedType.IInspectable)] sbyte Param1);
     void TestMethod_System_SByte_HString([MarshalAs(UnmanagedType.HString)] sbyte Param1);
     void TestMethod_System_SByte_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] sbyte Param1);
+    #endregion
+
+    #region short
     void TestMethod_System_Int16_Bool([MarshalAs(UnmanagedType.Bool)] short Param1);
     void TestMethod_System_Int16_VariantBool([MarshalAs(UnmanagedType.VariantBool)] short Param1);
     void TestMethod_System_Int16_I1([MarshalAs(UnmanagedType.I1)] short Param1);
@@ -163,6 +173,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Int16_IInspectable([MarshalAs(UnmanagedType.IInspectable)] short Param1);
     void TestMethod_System_Int16_HString([MarshalAs(UnmanagedType.HString)] short Param1);
     void TestMethod_System_Int16_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] short Param1);
+    #endregion
+
+    #region ushort
     void TestMethod_System_UInt16_Bool([MarshalAs(UnmanagedType.Bool)] ushort Param1);
     void TestMethod_System_UInt16_VariantBool([MarshalAs(UnmanagedType.VariantBool)] ushort Param1);
     void TestMethod_System_UInt16_I1([MarshalAs(UnmanagedType.I1)] ushort Param1);
@@ -198,6 +211,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_UInt16_IInspectable([MarshalAs(UnmanagedType.IInspectable)] ushort Param1);
     void TestMethod_System_UInt16_HString([MarshalAs(UnmanagedType.HString)] ushort Param1);
     void TestMethod_System_UInt16_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] ushort Param1);
+    #endregion
+
+    #region uint
     void TestMethod_System_UInt32_Bool([MarshalAs(UnmanagedType.Bool)] uint Param1);
     void TestMethod_System_UInt32_VariantBool([MarshalAs(UnmanagedType.VariantBool)] uint Param1);
     void TestMethod_System_UInt32_I1([MarshalAs(UnmanagedType.I1)] uint Param1);
@@ -233,6 +249,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_UInt32_IInspectable([MarshalAs(UnmanagedType.IInspectable)] uint Param1);
     void TestMethod_System_UInt32_HString([MarshalAs(UnmanagedType.HString)] uint Param1);
     void TestMethod_System_UInt32_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] uint Param1);
+    #endregion
+
+    #region int
     void TestMethod_System_Int32_Bool([MarshalAs(UnmanagedType.Bool)] int Param1);
     void TestMethod_System_Int32_VariantBool([MarshalAs(UnmanagedType.VariantBool)] int Param1);
     void TestMethod_System_Int32_I1([MarshalAs(UnmanagedType.I1)] int Param1);
@@ -268,6 +287,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Int32_IInspectable([MarshalAs(UnmanagedType.IInspectable)] int Param1);
     void TestMethod_System_Int32_HString([MarshalAs(UnmanagedType.HString)] int Param1);
     void TestMethod_System_Int32_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] int Param1);
+    #endregion
+
+    #region ulong
     void TestMethod_System_UInt64_Bool([MarshalAs(UnmanagedType.Bool)] ulong Param1);
     void TestMethod_System_UInt64_VariantBool([MarshalAs(UnmanagedType.VariantBool)] ulong Param1);
     void TestMethod_System_UInt64_I1([MarshalAs(UnmanagedType.I1)] ulong Param1);
@@ -303,6 +325,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_UInt64_IInspectable([MarshalAs(UnmanagedType.IInspectable)] ulong Param1);
     void TestMethod_System_UInt64_HString([MarshalAs(UnmanagedType.HString)] ulong Param1);
     void TestMethod_System_UInt64_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] ulong Param1);
+    #endregion
+
+    #region long
     void TestMethod_System_Int64_Bool([MarshalAs(UnmanagedType.Bool)] long Param1);
     void TestMethod_System_Int64_VariantBool([MarshalAs(UnmanagedType.VariantBool)] long Param1);
     void TestMethod_System_Int64_I1([MarshalAs(UnmanagedType.I1)] long Param1);
@@ -338,6 +363,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Int64_IInspectable([MarshalAs(UnmanagedType.IInspectable)] long Param1);
     void TestMethod_System_Int64_HString([MarshalAs(UnmanagedType.HString)] long Param1);
     void TestMethod_System_Int64_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] long Param1);
+    #endregion
+
+    #region float
     void TestMethod_System_Single_Bool([MarshalAs(UnmanagedType.Bool)] float Param1);
     void TestMethod_System_Single_VariantBool([MarshalAs(UnmanagedType.VariantBool)] float Param1);
     void TestMethod_System_Single_I1([MarshalAs(UnmanagedType.I1)] float Param1);
@@ -373,6 +401,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Single_IInspectable([MarshalAs(UnmanagedType.IInspectable)] float Param1);
     void TestMethod_System_Single_HString([MarshalAs(UnmanagedType.HString)] float Param1);
     void TestMethod_System_Single_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] float Param1);
+    #endregion
+
+    #region double
     void TestMethod_System_Double_Bool([MarshalAs(UnmanagedType.Bool)] double Param1);
     void TestMethod_System_Double_VariantBool([MarshalAs(UnmanagedType.VariantBool)] double Param1);
     void TestMethod_System_Double_I1([MarshalAs(UnmanagedType.I1)] double Param1);
@@ -408,6 +439,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Double_IInspectable([MarshalAs(UnmanagedType.IInspectable)] double Param1);
     void TestMethod_System_Double_HString([MarshalAs(UnmanagedType.HString)] double Param1);
     void TestMethod_System_Double_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] double Param1);
+    #endregion
+
+    #region string
     void TestMethod_System_String_Bool([MarshalAs(UnmanagedType.Bool)] string Param1);
     void TestMethod_System_String_VariantBool([MarshalAs(UnmanagedType.VariantBool)] string Param1);
     void TestMethod_System_String_I1([MarshalAs(UnmanagedType.I1)] string Param1);
@@ -443,6 +477,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_String_IInspectable([MarshalAs(UnmanagedType.IInspectable)] string Param1);
     void TestMethod_System_String_HString([MarshalAs(UnmanagedType.HString)] string Param1);
     void TestMethod_System_String_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] string Param1);
+    #endregion
+
+    #region char
     void TestMethod_System_Char_Bool([MarshalAs(UnmanagedType.Bool)] char Param1);
     void TestMethod_System_Char_VariantBool([MarshalAs(UnmanagedType.VariantBool)] char Param1);
     void TestMethod_System_Char_I1([MarshalAs(UnmanagedType.I1)] char Param1);
@@ -478,6 +515,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Char_IInspectable([MarshalAs(UnmanagedType.IInspectable)] char Param1);
     void TestMethod_System_Char_HString([MarshalAs(UnmanagedType.HString)] char Param1);
     void TestMethod_System_Char_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] char Param1);
+    #endregion
+
+    #region object
     void TestMethod_System_Object_Bool([MarshalAs(UnmanagedType.Bool)] object Param1);
     void TestMethod_System_Object_VariantBool([MarshalAs(UnmanagedType.VariantBool)] object Param1);
     void TestMethod_System_Object_I1([MarshalAs(UnmanagedType.I1)] object Param1);
@@ -513,6 +553,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Object_IInspectable([MarshalAs(UnmanagedType.IInspectable)] object Param1);
     void TestMethod_System_Object_HString([MarshalAs(UnmanagedType.HString)] object Param1);
     void TestMethod_System_Object_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] object Param1);
+    #endregion
+
+    #region objectArray
     void TestMethod_System_Object___Bool([MarshalAs(UnmanagedType.Bool)] object[] Param1);
     void TestMethod_System_Object___VariantBool([MarshalAs(UnmanagedType.VariantBool)] object[] Param1);
     void TestMethod_System_Object___I1([MarshalAs(UnmanagedType.I1)] object[] Param1);
@@ -548,6 +591,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Object___IInspectable([MarshalAs(UnmanagedType.IInspectable)] object[] Param1);
     void TestMethod_System_Object___HString([MarshalAs(UnmanagedType.HString)] object[] Param1);
     void TestMethod_System_Object___LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] object[] Param1);
+    #endregion
+
+    #region IEnumerator
     void TestMethod_System_Collections_IEnumerator_Bool([MarshalAs(UnmanagedType.Bool)] IEnumerator Param1);
     void TestMethod_System_Collections_IEnumerator_VariantBool([MarshalAs(UnmanagedType.VariantBool)] IEnumerator Param1);
     void TestMethod_System_Collections_IEnumerator_I1([MarshalAs(UnmanagedType.I1)] IEnumerator Param1);
@@ -583,6 +629,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Collections_IEnumerator_IInspectable([MarshalAs(UnmanagedType.IInspectable)] IEnumerator Param1);
     void TestMethod_System_Collections_IEnumerator_HString([MarshalAs(UnmanagedType.HString)] IEnumerator Param1);
     void TestMethod_System_Collections_IEnumerator_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] IEnumerator Param1);
+    #endregion
+
+    #region DateTime
     void TestMethod_System_DateTime_Bool([MarshalAs(UnmanagedType.Bool)] DateTime Param1);
     void TestMethod_System_DateTime_VariantBool([MarshalAs(UnmanagedType.VariantBool)] DateTime Param1);
     void TestMethod_System_DateTime_I1([MarshalAs(UnmanagedType.I1)] DateTime Param1);
@@ -618,6 +667,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_DateTime_IInspectable([MarshalAs(UnmanagedType.IInspectable)] DateTime Param1);
     void TestMethod_System_DateTime_HString([MarshalAs(UnmanagedType.HString)] DateTime Param1);
     void TestMethod_System_DateTime_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] DateTime Param1);
+    #endregion
+
+    #region Guid
     void TestMethod_System_Guid_Bool([MarshalAs(UnmanagedType.Bool)] Guid Param1);
     void TestMethod_System_Guid_VariantBool([MarshalAs(UnmanagedType.VariantBool)] Guid Param1);
     void TestMethod_System_Guid_I1([MarshalAs(UnmanagedType.I1)] Guid Param1);
@@ -653,6 +705,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Guid_IInspectable([MarshalAs(UnmanagedType.IInspectable)] Guid Param1);
     void TestMethod_System_Guid_HString([MarshalAs(UnmanagedType.HString)] Guid Param1);
     void TestMethod_System_Guid_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] Guid Param1);
+    #endregion
+
+    #region Color
     void TestMethod_System_Drawing_Color_Bool([MarshalAs(UnmanagedType.Bool)] Color Param1);
     void TestMethod_System_Drawing_Color_VariantBool([MarshalAs(UnmanagedType.VariantBool)] Color Param1);
     void TestMethod_System_Drawing_Color_I1([MarshalAs(UnmanagedType.I1)] Color Param1);
@@ -688,6 +743,9 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Drawing_Color_IInspectable([MarshalAs(UnmanagedType.IInspectable)] Color Param1);
     void TestMethod_System_Drawing_Color_HString([MarshalAs(UnmanagedType.HString)] Color Param1);
     void TestMethod_System_Drawing_Color_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] Color Param1);
+    #endregion
+
+    #region decimal
     void TestMethod_System_Decimal_Bool([MarshalAs(UnmanagedType.Bool)] decimal Param1);
     void TestMethod_System_Decimal_VariantBool([MarshalAs(UnmanagedType.VariantBool)] decimal Param1);
     void TestMethod_System_Decimal_I1([MarshalAs(UnmanagedType.I1)] decimal Param1);
@@ -723,4 +781,10 @@ public interface IDemoInterfaceWithMarshalAs
     void TestMethod_System_Decimal_IInspectable([MarshalAs(UnmanagedType.IInspectable)] decimal Param1);
     void TestMethod_System_Decimal_HString([MarshalAs(UnmanagedType.HString)] decimal Param1);
     void TestMethod_System_Decimal_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] decimal Param1);
+    #endregion
+
+    #region Marshal the return value 
+    [return: MarshalAs(UnmanagedType.IUnknown)]
+    IList TestMethod_ReturnValue_System_IList_IUnknown();
+    #endregion
 }

--- a/src/dscom.demo/assembly1/IDemoInterfaceWithMarshalAs.cs
+++ b/src/dscom.demo/assembly1/IDemoInterfaceWithMarshalAs.cs
@@ -786,7 +786,41 @@ public interface IDemoInterfaceWithMarshalAs
     #region Marshal the IList values in return and parameters
     [return: MarshalAs(UnmanagedType.IUnknown)]
     IList TestMethod_ReturnValue_System_IList_IUnknown();
-    void TestMethod_System_IList_SaveArray([MarshalAs(UnmanagedType.SafeArray)] IList elements);
+    void TestMethod_System_IList_Bool([MarshalAs(UnmanagedType.Bool)] IList Param1);
+    void TestMethod_System_IList_VariantBool([MarshalAs(UnmanagedType.VariantBool)] IList Param1);
+    void TestMethod_System_IList_I1([MarshalAs(UnmanagedType.I1)] IList Param1);
+    void TestMethod_System_IList_U1([MarshalAs(UnmanagedType.U1)] IList Param1);
+    void TestMethod_System_IList_I2([MarshalAs(UnmanagedType.I2)] IList Param1);
+    void TestMethod_System_IList_U2([MarshalAs(UnmanagedType.U2)] IList Param1);
+    void TestMethod_System_IList_I4([MarshalAs(UnmanagedType.I4)] IList Param1);
+    void TestMethod_System_IList_U4([MarshalAs(UnmanagedType.U4)] IList Param1);
+    void TestMethod_System_IList_I8([MarshalAs(UnmanagedType.I8)] IList Param1);
+    void TestMethod_System_IList_U8([MarshalAs(UnmanagedType.U8)] IList Param1);
+    void TestMethod_System_IList_R4([MarshalAs(UnmanagedType.R4)] IList Param1);
+    void TestMethod_System_IList_R8([MarshalAs(UnmanagedType.R8)] IList Param1);
+    void TestMethod_System_IList_Currency([MarshalAs(UnmanagedType.Currency)] IList Param1);
+    void TestMethod_System_IList_BStr([MarshalAs(UnmanagedType.BStr)] IList Param1);
+    void TestMethod_System_IList_LPStr([MarshalAs(UnmanagedType.LPStr)] IList Param1);
+    void TestMethod_System_IList_LPWStr([MarshalAs(UnmanagedType.LPWStr)] IList Param1);
+    void TestMethod_System_IList_LPTStr([MarshalAs(UnmanagedType.LPTStr)] IList Param1);
+    void TestMethod_System_IList_IUnknown([MarshalAs(UnmanagedType.IUnknown)] IList Param1);
+    void TestMethod_System_IList_IDispatch([MarshalAs(UnmanagedType.IDispatch)] IList Param1);
+    void TestMethod_System_IList_Struct([MarshalAs(UnmanagedType.Struct)] IList Param1);
+    void TestMethod_System_IList_Interface([MarshalAs(UnmanagedType.Interface)] IList Param1);
+    void TestMethod_System_IList_SafeArray([MarshalAs(UnmanagedType.SafeArray)] IList Param1);
+    void TestMethod_System_IList_SysInt([MarshalAs(UnmanagedType.SysInt)] IList Param1);
+    void TestMethod_System_IList_SysUInt([MarshalAs(UnmanagedType.SysUInt)] IList Param1);
+    void TestMethod_System_IList_VBByRefStr([MarshalAs(UnmanagedType.VBByRefStr)] IList Param1);
+    void TestMethod_System_IList_AnsiBStr([MarshalAs(UnmanagedType.AnsiBStr)] IList Param1);
+    void TestMethod_System_IList_TBStr([MarshalAs(UnmanagedType.TBStr)] IList Param1);
+    void TestMethod_System_IList_FunctionPtr([MarshalAs(UnmanagedType.FunctionPtr)] IList Param1);
+    void TestMethod_System_IList_AsAny([MarshalAs(UnmanagedType.AsAny)] IList Param1);
+    void TestMethod_System_IList_LPArray([MarshalAs(UnmanagedType.LPArray)] IList Param1);
+    void TestMethod_System_IList_LPStruct([MarshalAs(UnmanagedType.LPStruct)] IList Param1);
+    void TestMethod_System_IList_Error([MarshalAs(UnmanagedType.Error)] IList Param1);
+    void TestMethod_System_IList_IInspectable([MarshalAs(UnmanagedType.IInspectable)] IList Param1);
+    void TestMethod_System_IList_HString([MarshalAs(UnmanagedType.HString)] IList Param1);
+    void TestMethod_System_IList_LPUTF8Str([MarshalAs(UnmanagedType.LPUTF8Str)] IList Param1);
 
     #endregion
 }

--- a/src/dscom.test/TypeLibExporterNotifySink.cs
+++ b/src/dscom.test/TypeLibExporterNotifySink.cs
@@ -18,8 +18,11 @@ public class TypeLibExporterNotifySink : ITypeLibExporterNotifySink, ITypeLibExp
 {
     public TypeLibExporterNotifySink() { }
 
+    public List<ReportedEvent> ReportedEvents { get; } = new List<ReportedEvent>();
+
     public void ReportEvent(ExporterEventKind eventKind, int eventCode, string eventMsg)
     {
+        ReportedEvents.Add(new ReportedEvent() { EventKind = eventKind, EventCode = eventCode, EventMsg = eventMsg });
         Console.WriteLine($"{eventKind}:{eventCode}:{eventMsg}");
     }
 
@@ -32,4 +35,13 @@ public class TypeLibExporterNotifySink : ITypeLibExporterNotifySink, ITypeLibExp
     {
         return new string[] { "TOUPPERCASE", "tolowercase" };
     }
+}
+
+public struct ReportedEvent
+{
+    public ExporterEventKind EventKind { get; set; }
+
+    public int EventCode { get; set; }
+
+    public string EventMsg { get; set; }
 }

--- a/src/dscom.test/TypeLibExporterNotifySink.cs
+++ b/src/dscom.test/TypeLibExporterNotifySink.cs
@@ -16,12 +16,11 @@ namespace dSPACE.Runtime.InteropServices.Tests;
 
 public class TypeLibExporterNotifySink : ITypeLibExporterNotifySink, ITypeLibExporterNameProvider
 {
-    public TypeLibExporterNotifySink()
-    { }
+    public TypeLibExporterNotifySink() { }
 
     public void ReportEvent(ExporterEventKind eventKind, int eventCode, string eventMsg)
     {
-
+        Console.WriteLine($"{eventKind}:{eventCode}:{eventMsg}");
     }
 
     public object ResolveRef(Assembly assembly)

--- a/src/dscom.test/TypeLibExporterNotifySink.cs
+++ b/src/dscom.test/TypeLibExporterNotifySink.cs
@@ -23,7 +23,6 @@ public class TypeLibExporterNotifySink : ITypeLibExporterNotifySink, ITypeLibExp
     public void ReportEvent(ExporterEventKind eventKind, int eventCode, string eventMsg)
     {
         ReportedEvents.Add(new ReportedEvent() { EventKind = eventKind, EventCode = eventCode, EventMsg = eventMsg });
-        Console.WriteLine($"{eventKind}:{eventCode}:{eventMsg}");
     }
 
     public object ResolveRef(Assembly assembly)

--- a/src/dscom.test/builder/DynamicAssemblyBuilder.cs
+++ b/src/dscom.test/builder/DynamicAssemblyBuilder.cs
@@ -67,7 +67,8 @@ internal class DynamicAssemblyBuilder : DynamicBuilder<DynamicAssemblyBuilder>
         var typeLibConverter = new TypeLibConverter();
 
         var tlbFilePath = storeOnDisk ? TypeLibPath : string.Empty;
-        if (typeLibConverter.ConvertAssemblyToTypeLib(ModuleBuilder.Assembly, tlbFilePath, new TypeLibExporterNotifySink()) is not ITypeLib2 typelib)
+        var typeLibExporterNotifySink = new TypeLibExporterNotifySink();
+        if (typeLibConverter.ConvertAssemblyToTypeLib(ModuleBuilder.Assembly, tlbFilePath, typeLibExporterNotifySink) is not ITypeLib2 typelib)
         {
             throw new COMException("Cannot create type library for this dynamic assembly");
         }
@@ -92,7 +93,7 @@ internal class DynamicAssemblyBuilder : DynamicBuilder<DynamicAssemblyBuilder>
 
         AppDomain.CurrentDomain.AssemblyResolve -= ResolveEventHandler;
 
-        return new DynamicAssemblyBuilderResult(typelib, ModuleBuilder.Assembly);
+        return new DynamicAssemblyBuilderResult(typelib, ModuleBuilder.Assembly, typeLibExporterNotifySink);
     }
 
     internal DynamicTypeBuilder WithInterface(string interfaceName)

--- a/src/dscom.test/builder/DynamicAssemblyBuilder.cs
+++ b/src/dscom.test/builder/DynamicAssemblyBuilder.cs
@@ -69,7 +69,7 @@ internal class DynamicAssemblyBuilder : DynamicBuilder<DynamicAssemblyBuilder>
         var tlbFilePath = storeOnDisk ? TypeLibPath : string.Empty;
         if (typeLibConverter.ConvertAssemblyToTypeLib(ModuleBuilder.Assembly, tlbFilePath, new TypeLibExporterNotifySink()) is not ITypeLib2 typelib)
         {
-            throw new COMException("Cannot create type libray for this dynamic assembly");
+            throw new COMException("Cannot create type library for this dynamic assembly");
         }
 
         if (storeOnDisk && typelib is ICreateTypeLib2 createTypeLib2)

--- a/src/dscom.test/builder/DynamicAssemblyBuilderResult.cs
+++ b/src/dscom.test/builder/DynamicAssemblyBuilderResult.cs
@@ -16,11 +16,14 @@ namespace dSPACE.Runtime.InteropServices.Tests;
 
 internal class DynamicAssemblyBuilderResult
 {
-    public DynamicAssemblyBuilderResult(ITypeLib2 typeLib, Assembly assembly)
+    public DynamicAssemblyBuilderResult(ITypeLib2 typeLib, Assembly assembly, TypeLibExporterNotifySink typeLibExporterNotifySink)
     {
         TypeLib = typeLib;
         Assembly = assembly;
+        TypeLibExporterNotifySink = typeLibExporterNotifySink;
     }
+
+    public TypeLibExporterNotifySink TypeLibExporterNotifySink { get; }
 
     public ITypeLib2 TypeLib { get; }
 

--- a/src/dscom.test/tests/MarshalAsTest.cs
+++ b/src/dscom.test/tests/MarshalAsTest.cs
@@ -223,7 +223,7 @@ public class MarshalAsTest : BaseTest
     [InlineData(UnmanagedType.IInspectable, VarEnum.VT_UNKNOWN)]
     [InlineData(UnmanagedType.HString, VarEnum.VT_UNKNOWN)]
     [InlineData(UnmanagedType.LPUTF8Str, VarEnum.VT_UNKNOWN)]
-    public void MethodWithReturnValueAndMarshalAsAttribute_NoWarning(UnmanagedType marshalType, VarEnum varEnumType)
+    public void MethodWithReturnTypeIListAndMarshalAsAttribute_NoWarningExpected(UnmanagedType marshalType, VarEnum varEnumType)
     {
         var type = typeof(System.Collections.IList);
 

--- a/src/dscom.test/tests/MarshalAsTest.cs
+++ b/src/dscom.test/tests/MarshalAsTest.cs
@@ -189,16 +189,51 @@ public class MarshalAsTest : BaseTest
 
     [Theory]
     [InlineData(UnmanagedType.IUnknown, VarEnum.VT_UNKNOWN)]
-    [InlineData(UnmanagedType.Bool, VarEnum.VT_BOOL)]
+    [InlineData(UnmanagedType.Bool, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.VariantBool, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.I1, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.U1, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.I2, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.U2, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.I4, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.U4, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.I8, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.U8, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.R4, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.R8, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.Currency, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.BStr, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.LPStr, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.LPWStr, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.LPTStr, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.IDispatch, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.Struct, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.Interface, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.SafeArray, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.SysInt, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.SysUInt, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.VBByRefStr, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.AnsiBStr, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.TBStr, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.FunctionPtr, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.AsAny, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.LPArray, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.LPStruct, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.Error, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.IInspectable, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.HString, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.LPUTF8Str, VarEnum.VT_UNKNOWN)]
     public void MethodWithReturnValueAndMarshalAsAttribute_NoWarning(UnmanagedType marshalType, VarEnum varEnumType)
     {
+        var type = typeof(System.Collections.IList);
+
         var result = CreateAssembly(CreateAssemblyName())
             .WithInterface("TestInterface")
                 .WithMethod("TestMethod")
-                    .WithReturnType(typeof(System.Collections.IList))
+                    .WithReturnType(type)
                     .WithReturnTypeCustomAttribute<MarshalAsAttribute>(marshalType)
                     .Build()
-               .Build()
+                .Build()
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
@@ -208,44 +243,6 @@ public class MarshalAsTest : BaseTest
         funcDesc!.Value.cParams.Should().Be(0);
 
         funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(varEnumType, $"First Parameter type of TestMethod should be {varEnumType}");
-
-        // TODO: 
-        // Check for:
-        // MarshalAs(UnmanagedType.Bool
-        // MarshalAs(UnmanagedType.VariantBool
-        // MarshalAs(UnmanagedType.I1
-        // MarshalAs(UnmanagedType.U1
-        // MarshalAs(UnmanagedType.I2
-        // MarshalAs(UnmanagedType.U2
-        // MarshalAs(UnmanagedType.I4
-        // MarshalAs(UnmanagedType.U4
-        // MarshalAs(UnmanagedType.I8
-        // MarshalAs(UnmanagedType.U8
-        // MarshalAs(UnmanagedType.R4
-        // MarshalAs(UnmanagedType.R8
-        // MarshalAs(UnmanagedType.Currency
-        // MarshalAs(UnmanagedType.BStr
-        // MarshalAs(UnmanagedType.LPStr
-        // MarshalAs(UnmanagedType.LPWStr
-        // MarshalAs(UnmanagedType.LPTStr
-        // MarshalAs(UnmanagedType.IUnknown
-        // MarshalAs(UnmanagedType.IDispatch
-        // MarshalAs(UnmanagedType.Struct
-        // MarshalAs(UnmanagedType.Interface
-        // MarshalAs(UnmanagedType.SafeArray
-        // MarshalAs(UnmanagedType.SysInt
-        // MarshalAs(UnmanagedType.SysUInt
-        // MarshalAs(UnmanagedType.VBByRefStr
-        // MarshalAs(UnmanagedType.AnsiBStr
-        // MarshalAs(UnmanagedType.TBStr
-        // MarshalAs(UnmanagedType.FunctionPtr
-        // MarshalAs(UnmanagedType.AsAny
-        // MarshalAs(UnmanagedType.LPArray
-        // MarshalAs(UnmanagedType.LPStruct
-        // MarshalAs(UnmanagedType.Error
-        // MarshalAs(UnmanagedType.IInspectable
-        // MarshalAs(UnmanagedType.HString
-        // MarshalAs(UnmanagedType.LPUTF8Str
 
         result.TypeLibExporterNotifySink.ReportedEvents.Count.Should().Be(1);
     }

--- a/src/dscom.test/tests/MarshalAsTest.cs
+++ b/src/dscom.test/tests/MarshalAsTest.cs
@@ -187,14 +187,16 @@ public class MarshalAsTest : BaseTest
         }
     }
 
-    [Fact]
-    public void MethodWithReturnValueAndMarshalAsAttribute_NoWarning()
+    [Theory]
+    [InlineData(UnmanagedType.IUnknown, VarEnum.VT_UNKNOWN)]
+    [InlineData(UnmanagedType.Bool, VarEnum.VT_BOOL)]
+    public void MethodWithReturnValueAndMarshalAsAttribute_NoWarning(UnmanagedType marshalType, VarEnum varEnumType)
     {
         var result = CreateAssembly(CreateAssemblyName())
             .WithInterface("TestInterface")
                 .WithMethod("TestMethod")
                     .WithReturnType(typeof(System.Collections.IList))
-                    .WithReturnTypeCustomAttribute<MarshalAsAttribute>(UnmanagedType.IUnknown)
+                    .WithReturnTypeCustomAttribute<MarshalAsAttribute>(marshalType)
                     .Build()
                .Build()
             .Build();
@@ -204,7 +206,48 @@ public class MarshalAsTest : BaseTest
         using var funcDesc = typeInfo!.GetFuncDescByName("TestMethod");
         funcDesc.Should().NotBeNull("TestMethod should be available");
         funcDesc!.Value.cParams.Should().Be(0);
-        // ToDo: What additional properties can be tested here 
+
+        funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(varEnumType, $"First Parameter type of TestMethod should be {varEnumType}");
+
+        // TODO: 
+        // Check for:
+        // MarshalAs(UnmanagedType.Bool
+        // MarshalAs(UnmanagedType.VariantBool
+        // MarshalAs(UnmanagedType.I1
+        // MarshalAs(UnmanagedType.U1
+        // MarshalAs(UnmanagedType.I2
+        // MarshalAs(UnmanagedType.U2
+        // MarshalAs(UnmanagedType.I4
+        // MarshalAs(UnmanagedType.U4
+        // MarshalAs(UnmanagedType.I8
+        // MarshalAs(UnmanagedType.U8
+        // MarshalAs(UnmanagedType.R4
+        // MarshalAs(UnmanagedType.R8
+        // MarshalAs(UnmanagedType.Currency
+        // MarshalAs(UnmanagedType.BStr
+        // MarshalAs(UnmanagedType.LPStr
+        // MarshalAs(UnmanagedType.LPWStr
+        // MarshalAs(UnmanagedType.LPTStr
+        // MarshalAs(UnmanagedType.IUnknown
+        // MarshalAs(UnmanagedType.IDispatch
+        // MarshalAs(UnmanagedType.Struct
+        // MarshalAs(UnmanagedType.Interface
+        // MarshalAs(UnmanagedType.SafeArray
+        // MarshalAs(UnmanagedType.SysInt
+        // MarshalAs(UnmanagedType.SysUInt
+        // MarshalAs(UnmanagedType.VBByRefStr
+        // MarshalAs(UnmanagedType.AnsiBStr
+        // MarshalAs(UnmanagedType.TBStr
+        // MarshalAs(UnmanagedType.FunctionPtr
+        // MarshalAs(UnmanagedType.AsAny
+        // MarshalAs(UnmanagedType.LPArray
+        // MarshalAs(UnmanagedType.LPStruct
+        // MarshalAs(UnmanagedType.Error
+        // MarshalAs(UnmanagedType.IInspectable
+        // MarshalAs(UnmanagedType.HString
+        // MarshalAs(UnmanagedType.LPUTF8Str
+
+        result.TypeLibExporterNotifySink.ReportedEvents.Count.Should().Be(1);
     }
 
     [Theory]

--- a/src/dscom.test/tests/MarshalAsTest.cs
+++ b/src/dscom.test/tests/MarshalAsTest.cs
@@ -192,7 +192,8 @@ public class MarshalAsTest : BaseTest
     {
         var result = CreateAssembly(CreateAssemblyName())
             .WithInterface("TestInterface")
-                .WithMethod("TestMethod").WithReturnType(typeof(System.Collections.IList))
+                .WithMethod("TestMethod")
+                    .WithReturnType(typeof(System.Collections.IList))
                     .WithReturnTypeCustomAttribute<MarshalAsAttribute>(UnmanagedType.IUnknown)
                     .Build()
                .Build()
@@ -203,7 +204,7 @@ public class MarshalAsTest : BaseTest
         using var funcDesc = typeInfo!.GetFuncDescByName("TestMethod");
         funcDesc.Should().NotBeNull("TestMethod should be available");
         funcDesc!.Value.cParams.Should().Be(0);
-
+        // ToDo: What additional properties can be tested here 
     }
 
     [Theory]

--- a/src/dscom.test/tests/MarshalAsTest.cs
+++ b/src/dscom.test/tests/MarshalAsTest.cs
@@ -48,17 +48,17 @@ public class MarshalAsTest : BaseTest
 
             if (kv.Value == null)
             {
-                // Is not suppported TLBX_E_BAD_NATIVETYPE
-                funcDesc.Should().BeNull($"{methodName} should not no be availble");
+                // Is not supported TLBX_E_BAD_NATIVETYPE
+                funcDesc.Should().BeNull($"{methodName} should not no be available");
             }
             else
             {
                 // Is is supported
-                funcDesc.Should().NotBeNull($"{methodName} should be availble");
+                funcDesc.Should().NotBeNull($"{methodName} should be available");
 
                 // check first parameter
                 var firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDesc!.Value.lprgelemdescParam);
-                firstParam.tdesc.GetVarEnum().Should().Be(kv.Value, $"First parameter of {methodName} should be availble {kv.Value}");
+                firstParam.tdesc.GetVarEnum().Should().Be(kv.Value, $"First parameter of {methodName} should be available {kv.Value}");
             }
         }
     }
@@ -94,17 +94,17 @@ public class MarshalAsTest : BaseTest
 
             if (kv.Value == null)
             {
-                // Is not suppported TLBX_E_BAD_NATIVETYPE
-                funcDescSet.Should().BeNull($"{methodName} should not no be availble");
+                // Is not supported TLBX_E_BAD_NATIVETYPE
+                funcDescSet.Should().BeNull($"{methodName} should not no be available");
             }
             else
             {
                 // Is is supported
-                funcDescSet.Should().NotBeNull($"{methodName} should be availble");
+                funcDescSet.Should().NotBeNull($"{methodName} should be available");
 
                 // check first parameter
                 var firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDescSet!.Value.lprgelemdescParam);
-                firstParam.tdesc.GetVarEnum().Should().Be(kv.Value, $"First parameter of {methodName} should be availble {kv.Value}");
+                firstParam.tdesc.GetVarEnum().Should().Be(kv.Value, $"First parameter of {methodName} should be available {kv.Value}");
             }
 
             // Check getter
@@ -112,27 +112,27 @@ public class MarshalAsTest : BaseTest
 
             if (kv.Value == null)
             {
-                // Is not suppported TLBX_E_BAD_NATIVETYPE
-                funcDescGet.Should().BeNull($"{methodName} should not no be availble");
+                // Is not supported TLBX_E_BAD_NATIVETYPE
+                funcDescGet.Should().BeNull($"{methodName} should not no be available");
             }
             else
             {
                 // Is is supported
-                funcDescGet.Should().NotBeNull($"{methodName} should be availble");
+                funcDescGet.Should().NotBeNull($"{methodName} should be available");
 
                 if (interfaceType == ComInterfaceType.InterfaceIsIUnknown)
                 {
                     // Return type should be VT_HRESULT
-                    funcDescGet!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(VarEnum.VT_HRESULT, $"Return type of {methodName} should be availble {kv.Value}");
+                    funcDescGet!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(VarEnum.VT_HRESULT, $"Return type of {methodName} should be available {kv.Value}");
 
                     // check first parameter
                     var firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDescSet!.Value.lprgelemdescParam);
-                    firstParam.tdesc.GetVarEnum().Should().Be(kv.Value, $"First parameter of {methodName} should be availble {kv.Value}");
+                    firstParam.tdesc.GetVarEnum().Should().Be(kv.Value, $"First parameter of {methodName} should be available {kv.Value}");
                 }
                 else
                 {
                     // Check return value
-                    funcDescGet!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(kv.Value, $"Return type of {methodName} should be availble {kv.Value}");
+                    funcDescGet!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(kv.Value, $"Return type of {methodName} should be available {kv.Value}");
                 }
             }
         }
@@ -165,26 +165,45 @@ public class MarshalAsTest : BaseTest
 
             if (kv.Value == null)
             {
-                // Is not suppported TLBX_E_BAD_NATIVETYPE
-                funcDesc.Should().BeNull($"{methodName} should not no be availble");
+                // Is not supported TLBX_E_BAD_NATIVETYPE
+                funcDesc.Should().BeNull($"{methodName} should not no be available");
             }
             else
             {
                 // Is is supported
-                funcDesc.Should().NotBeNull($"{methodName} should be availble");
+                funcDesc.Should().NotBeNull($"{methodName} should be available");
 
                 // return value should be VT_HRESULT
-                funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(VarEnum.VT_HRESULT, $"Return value of {methodName} should be availble and VarEnum.VT_HRESULT");
+                funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(VarEnum.VT_HRESULT, $"Return value of {methodName} should be available and VarEnum.VT_HRESULT");
 
                 // first parameter should be VT_PTR
                 var firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDesc!.Value.lprgelemdescParam);
-                firstParam.tdesc.GetVarEnum().Should().Be(VarEnum.VT_PTR, $"First parameter of {methodName} should be availble VarEnum.VT_PTR");
+                firstParam.tdesc.GetVarEnum().Should().Be(VarEnum.VT_PTR, $"First parameter of {methodName} should be available VarEnum.VT_PTR");
 
                 // first parameter inner type
                 var subtypeDesc = Marshal.PtrToStructure<TYPEDESC>(firstParam.tdesc.lpValue);
-                subtypeDesc.GetVarEnum().Should().Be(kv.Value, $"First parameter of {methodName} should be availble VarEnum.VT_PTR");
+                subtypeDesc.GetVarEnum().Should().Be(kv.Value, $"First parameter of {methodName} should be available VarEnum.VT_PTR");
             }
         }
+    }
+
+    [Fact]
+    public void MethodWithReturnValueAndMarshalAsAttribute_NoWarning()
+    {
+        var result = CreateAssembly(CreateAssemblyName())
+            .WithInterface("TestInterface")
+                .WithMethod("TestMethod").WithReturnType(typeof(System.Collections.IList))
+                    .WithReturnTypeCustomAttribute<MarshalAsAttribute>(UnmanagedType.IUnknown)
+                    .Build()
+               .Build()
+            .Build();
+
+        var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
+        typeInfo.Should().NotBeNull("TestInterface should be generated");
+        using var funcDesc = typeInfo!.GetFuncDescByName("TestMethod");
+        funcDesc.Should().NotBeNull("TestMethod should be available");
+        funcDesc!.Value.cParams.Should().Be(0);
+
     }
 
     [Theory]
@@ -215,16 +234,16 @@ public class MarshalAsTest : BaseTest
 
             if (kv.Value == null)
             {
-                // Is not suppported TLBX_E_BAD_NATIVETYPE
-                funcDesc.Should().BeNull($"{methodName} should not no be availble");
+                // Is not supported TLBX_E_BAD_NATIVETYPE
+                funcDesc.Should().BeNull($"{methodName} should not no be available");
             }
             else
             {
                 // Is is supported
-                funcDesc.Should().NotBeNull($"{methodName} should be availble");
+                funcDesc.Should().NotBeNull($"{methodName} should be available");
 
                 // check return value
-                funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(kv.Value, $"First parameter of {methodName} should be availble {kv.Value}");
+                funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(kv.Value, $"First parameter of {methodName} should be available {kv.Value}");
             }
         }
     }
@@ -356,17 +375,17 @@ public class MarshalAsTest : BaseTest
             // Array of Array not supported
             if (parameterType.IsArray)
             {
-                // Is not suppported TLBX_E_BAD_NATIVETYPE
-                funcDesc.Should().BeNull($"{methodName} should not no be availble");
+                // Is not supported TLBX_E_BAD_NATIVETYPE
+                funcDesc.Should().BeNull($"{methodName} should not no be available");
             }
             else
             {
                 // Is is supported
-                funcDesc.Should().NotBeNull($"{methodName} should be availble");
+                funcDesc.Should().NotBeNull($"{methodName} should be available");
 
                 // check first parameter
                 var firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDesc!.Value.lprgelemdescParam);
-                firstParam.tdesc.GetVarEnum().Should().Be(VarEnum.VT_SAFEARRAY, $"First parameter of {methodName} should be availble VarEnum.VT_SAFEARRAY");
+                firstParam.tdesc.GetVarEnum().Should().Be(VarEnum.VT_SAFEARRAY, $"First parameter of {methodName} should be available VarEnum.VT_SAFEARRAY");
                 var firstParamSub = Marshal.PtrToStructure<ELEMDESC>(firstParam.tdesc.lpValue);
                 if (firstParamSub.tdesc.lpValue != IntPtr.Zero && firstParamSub.tdesc.GetVarEnum() == VarEnum.VT_PTR)
                 {
@@ -433,19 +452,19 @@ public class MarshalAsTest : BaseTest
             funcDesc.Should().NotBeNull();
 
             // return value should be VT_PTR
-            funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(VarEnum.VT_PTR, $"Return value of {methodName} should be availble and VarEnum.VT_HRESULT");
+            funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(VarEnum.VT_PTR, $"Return value of {methodName} should be available and VarEnum.VT_HRESULT");
 
             // return value inner type should VT_USERDEFINED
             var subtypeDesc = Marshal.PtrToStructure<TYPEDESC>(funcDesc!.Value.elemdescFunc.tdesc.lpValue);
-            subtypeDesc.GetVarEnum().Should().Be(VarEnum.VT_USERDEFINED, $"First parameter of {methodName} should be availble VarEnum.VT_PTR");
+            subtypeDesc.GetVarEnum().Should().Be(VarEnum.VT_USERDEFINED, $"First parameter of {methodName} should be available VarEnum.VT_PTR");
 
             // first parameter should be VT_PTR
             var firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDesc!.Value.lprgelemdescParam);
-            firstParam.tdesc.GetVarEnum().Should().Be(VarEnum.VT_PTR, $"First parameter of {methodName} should be availble VarEnum.VT_PTR");
+            firstParam.tdesc.GetVarEnum().Should().Be(VarEnum.VT_PTR, $"First parameter of {methodName} should be available VarEnum.VT_PTR");
 
             // first parameter inner type should be VT_USERDEFINED
             subtypeDesc = Marshal.PtrToStructure<TYPEDESC>(firstParam.tdesc.lpValue);
-            subtypeDesc.GetVarEnum().Should().Be(VarEnum.VT_USERDEFINED, $"First parameter of {methodName} should be availble VarEnum.VT_PTR");
+            subtypeDesc.GetVarEnum().Should().Be(VarEnum.VT_USERDEFINED, $"First parameter of {methodName} should be available VarEnum.VT_PTR");
         }
     }
 

--- a/src/dscom/writer/ParameterWriter.cs
+++ b/src/dscom/writer/ParameterWriter.cs
@@ -181,6 +181,11 @@ internal class ParameterWriter : ElemDescBasedWriter
         {
             try
             {
+                if ((ParameterInfo.Attributes & ParameterAttributes.HasFieldMarshal) != 0)
+                {
+                    return true;
+                }
+
                 var type = ParameterInfo.ParameterType.GetUnderlayingType();
                 var notSpecialHandledValueType = !type.IsSpecialHandledValueType();
 


### PR DESCRIPTION
- Fixed various typos in the code and comments 
- Added a special handling that Parameters with MarshalAs attribute don't create a warning 
- Sorted the demo class 
- Extended the demo class to reproduce the problem from #50 
