### PR TITLE
Chore: Pacify Roslyn analyzers

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
     <NoWarn>CA1416;CA1401;CA1707;CA1720;CA1711;CA2201;CA1200;CA5351;CS0618;CA1305;</NoWarn>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <RollForward>LatestMajor</RollForward>
-    <Authors>Mathias Nissen;Mark Lechtermann;Sebastian Osterbrink</Authors>
+    <Authors>Mathias Nissen;Mark Lechtermann;Sebastian Osterbrink;Carsten Igel</Authors>
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/dscom.test/builder/DynamicAssemblyBuilder.cs
+++ b/src/dscom.test/builder/DynamicAssemblyBuilder.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
-internal class DynamicAssemblyBuilder : DynamicBuilder<DynamicAssemblyBuilder>
+internal sealed class DynamicAssemblyBuilder : DynamicBuilder<DynamicAssemblyBuilder>
 {
     public DynamicAssemblyBuilder(string name, AssemblyBuilder assemblyBuilder, string path) : base(name)
     {

--- a/src/dscom.test/builder/DynamicAssemblyBuilderResult.cs
+++ b/src/dscom.test/builder/DynamicAssemblyBuilderResult.cs
@@ -14,7 +14,7 @@
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
-internal class DynamicAssemblyBuilderResult
+internal sealed class DynamicAssemblyBuilderResult
 {
     public DynamicAssemblyBuilderResult(ITypeLib2 typeLib, Assembly assembly, TypeLibExporterNotifySink typeLibExporterNotifySink)
     {

--- a/src/dscom.test/builder/DynamicEnumBuilder.cs
+++ b/src/dscom.test/builder/DynamicEnumBuilder.cs
@@ -16,7 +16,7 @@ using System.Globalization;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
-internal class DynamicEnumBuilder : DynamicBuilder<DynamicEnumBuilder>
+internal sealed class DynamicEnumBuilder : DynamicBuilder<DynamicEnumBuilder>
 {
     public DynamicEnumBuilder(DynamicAssemblyBuilder dynamicTypeLibBuilder, string name, Type enumType) : base(name)
     {

--- a/src/dscom.test/builder/DynamicFieldBuilder.cs
+++ b/src/dscom.test/builder/DynamicFieldBuilder.cs
@@ -14,7 +14,7 @@
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
-internal class DynamicFieldBuilder : DynamicBuilder<DynamicFieldBuilder>
+internal sealed class DynamicFieldBuilder : DynamicBuilder<DynamicFieldBuilder>
 {
     public DynamicFieldBuilder(DynamicTypeBuilder dynamicTypeBuilder, string name, Type fieldType) : base(name)
     {

--- a/src/dscom.test/builder/DynamicMethodBuilder.cs
+++ b/src/dscom.test/builder/DynamicMethodBuilder.cs
@@ -14,7 +14,7 @@
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
-internal class DynamicMethodBuilder : DynamicBuilder<DynamicMethodBuilder>
+internal sealed class DynamicMethodBuilder : DynamicBuilder<DynamicMethodBuilder>
 {
     internal record struct DefaultValue(
         object? Value

--- a/src/dscom.test/builder/DynamicPropertyBuilder.cs
+++ b/src/dscom.test/builder/DynamicPropertyBuilder.cs
@@ -14,7 +14,7 @@
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
-internal class DynamicPropertyBuilder : DynamicBuilder<DynamicPropertyBuilder>
+internal sealed class DynamicPropertyBuilder : DynamicBuilder<DynamicPropertyBuilder>
 {
     public DynamicPropertyBuilder(DynamicTypeBuilder dynamicTypeBuilder, string name, Type propertyType, bool isSettable = true, bool isGettable = true) : base(name)
     {

--- a/src/dscom.test/builder/DynamicTypeBuilder.cs
+++ b/src/dscom.test/builder/DynamicTypeBuilder.cs
@@ -14,7 +14,7 @@
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
-internal class DynamicTypeBuilder : DynamicBuilder<DynamicTypeBuilder>
+internal sealed class DynamicTypeBuilder : DynamicBuilder<DynamicTypeBuilder>
 {
     public DynamicTypeBuilder(DynamicAssemblyBuilder dynamicTypeBuilder, string name, TypeAttributes typeAttributes, string[]? addInterfaceImplementation = null, Type? parentType = null) : base(name)
     {

--- a/src/dscom/ClassFactory.cs
+++ b/src/dscom/ClassFactory.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 namespace dSPACE.Runtime.InteropServices;
 
 [ComVisible(true)]
-internal class ClassFactory<T> : IClassFactory where T : new()
+internal sealed class ClassFactory<T> : IClassFactory where T : new()
 {
     public void CreateInstance(
         [MarshalAs(UnmanagedType.Interface)] object instancePointer,

--- a/src/dscom/DispatchIdCreator.cs
+++ b/src/dscom/DispatchIdCreator.cs
@@ -18,7 +18,7 @@ using dSPACE.Runtime.InteropServices.Writer;
 
 namespace dSPACE.Runtime.InteropServices;
 
-internal class DispatchIdCreator
+internal sealed class DispatchIdCreator
 {
     private readonly List<IDInfo> _dispIds = new();
 
@@ -120,7 +120,7 @@ internal class DispatchIdCreator
         }
     }
 
-    public class IDInfo
+    public sealed class IDInfo
     {
         public IDInfo(uint generatedId, uint? explicitId, MemberInfo memberInfo)
         {

--- a/src/dscom/NameResolver.cs
+++ b/src/dscom/NameResolver.cs
@@ -33,9 +33,10 @@ internal sealed class NameResolver
 
     public string GetMappedName(string name)
     {
-        if (_names.ContainsKey(name.ToLower(CultureInfo.InvariantCulture)))
+        var lowerCaseName = name.ToLower(CultureInfo.InvariantCulture);
+        if (_names.TryGetValue(lowerCaseName, out var mappedName))
         {
-            return _names[name.ToLower(CultureInfo.InvariantCulture)];
+            return mappedName;
         }
         return name;
     }

--- a/src/dscom/TypeProvider.cs
+++ b/src/dscom/TypeProvider.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices;
 
-internal class TypeProvider
+internal sealed class TypeProvider
 {
     public TypeProvider(WriterContext context, ICustomAttributeProvider customAttributeProvider, bool isMethod = true)
     {

--- a/src/dscom/exporter/CustomDataItemInfo.cs
+++ b/src/dscom/exporter/CustomDataItemInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Exporter;
 
-internal class CustomDataItemInfo : BaseInfo
+internal sealed class CustomDataItemInfo : BaseInfo
 {
     private static readonly Dictionary<Guid, string> _guids = new();
 

--- a/src/dscom/exporter/FunctionInfo.cs
+++ b/src/dscom/exporter/FunctionInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Exporter;
 
-internal class FunctionInfo : BaseInfo
+internal sealed class FunctionInfo : BaseInfo
 {
     public FunctionInfo(ITypeInfo2 typeInfo, FUNCDESC funcDesc, BaseInfo? parent, string itemName) : base(parent, itemName)
     {

--- a/src/dscom/exporter/ImplementationReferenceTypeInfo.cs
+++ b/src/dscom/exporter/ImplementationReferenceTypeInfo.cs
@@ -14,7 +14,7 @@
 
 namespace dSPACE.Runtime.InteropServices.Exporter;
 
-internal class ImplementationReferenceTypeInfo : ReferenceTypeInfo
+internal sealed class ImplementationReferenceTypeInfo : ReferenceTypeInfo
 {
     public ImplementationReferenceTypeInfo(ITypeInfo2 typeInfo, ITypeInfo2 typeInfoUsingType, int index, BaseInfo? parent, string itemName) : base(typeInfo, typeInfoUsingType, parent, itemName)
     {

--- a/src/dscom/exporter/ImportedReferenceTypeInfo.cs
+++ b/src/dscom/exporter/ImportedReferenceTypeInfo.cs
@@ -14,7 +14,7 @@
 
 namespace dSPACE.Runtime.InteropServices.Exporter;
 
-internal class ImportedReferenceTypeInfo : BaseInfo
+internal sealed class ImportedReferenceTypeInfo : BaseInfo
 {
     public ImportedReferenceTypeInfo(Guid importedTypeLibGuid, Guid importedTypeGuid, string importedTypeLibName, BaseInfo? parent, string itemName) : base(parent, itemName)
     {

--- a/src/dscom/exporter/ParameterDescriptionInfo.cs
+++ b/src/dscom/exporter/ParameterDescriptionInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Exporter;
 
-internal class ParameterDescriptionInfo : BaseInfo
+internal sealed class ParameterDescriptionInfo : BaseInfo
 {
     public ParameterDescriptionInfo(ELEMDESC descunion, BaseInfo? parent, string itemName) : this(descunion.desc, parent, itemName)
     {

--- a/src/dscom/exporter/ParameterInfo.cs
+++ b/src/dscom/exporter/ParameterInfo.cs
@@ -14,7 +14,7 @@
 
 namespace dSPACE.Runtime.InteropServices.Exporter;
 
-internal class ElementDescriptionInfo : BaseInfo
+internal sealed class ElementDescriptionInfo : BaseInfo
 {
     public ElementDescriptionInfo(ITypeInfo2 typeInfo, ELEMDESC elementDescription, string name, BaseInfo? parent, string itemName) : base(parent, itemName)
     {

--- a/src/dscom/exporter/TypeAttributeInfo.cs
+++ b/src/dscom/exporter/TypeAttributeInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Exporter;
 
-internal class TypeAttributeInfo : BaseInfo
+internal sealed class TypeAttributeInfo : BaseInfo
 {
     public TypeAttributeInfo(ITypeInfo2 typeInfo, BaseInfo? parent, string itemName) : base(parent, itemName)
     {

--- a/src/dscom/exporter/TypeDescriptionInfo.cs
+++ b/src/dscom/exporter/TypeDescriptionInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Exporter;
 
-internal class TypeDescriptionInfo : BaseInfo
+internal sealed class TypeDescriptionInfo : BaseInfo
 {
     public TypeDescriptionInfo(ITypeInfo2 typeInfo, TYPEDESC typeDesc, BaseInfo? parent, string itemName) : base(parent, itemName)
     {

--- a/src/dscom/exporter/TypeInfo.cs
+++ b/src/dscom/exporter/TypeInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Exporter;
 
-internal class TypeInfo : BaseInfo
+internal sealed class TypeInfo : BaseInfo
 {
     public TypeInfo(ITypeInfo2 typeInfo, BaseInfo? parent, string itemName) : base(parent, itemName)
     {

--- a/src/dscom/exporter/TypeLibAttributesInfo.cs
+++ b/src/dscom/exporter/TypeLibAttributesInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Exporter;
 
-internal class TypeLibAttributesInfo : BaseInfo
+internal sealed class TypeLibAttributesInfo : BaseInfo
 {
     public TypeLibAttributesInfo(ITypeLib2 typeLib, BaseInfo? parent, string itemName) : base(parent, itemName)
     {

--- a/src/dscom/exporter/TypelLibInfo.cs
+++ b/src/dscom/exporter/TypelLibInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Exporter;
 
-internal class TypelLibInfo : BaseInfo
+internal sealed class TypelLibInfo : BaseInfo
 {
     public TypelLibInfo(string file) : base(null, string.Empty)
     {

--- a/src/dscom/exporter/VariableDescriptionInfo.cs
+++ b/src/dscom/exporter/VariableDescriptionInfo.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Exporter;
 
-internal class VariableDescriptionInfo : BaseInfo
+internal sealed class VariableDescriptionInfo : BaseInfo
 {
     public VariableDescriptionInfo(ITypeInfo2 typeInfo, VARDESC varDesc, BaseInfo? parent, string itemName) : base(parent, itemName)
     {

--- a/src/dscom/internal/structs/VARIANT.cs
+++ b/src/dscom/internal/structs/VARIANT.cs
@@ -37,7 +37,7 @@ public struct VARIANT
     internal ulong longValue;
 
     [StructLayout(LayoutKind.Sequential)]
-    private struct Record
+    private readonly struct Record
     {
         private readonly IntPtr _record;
 

--- a/src/dscom/writer/ClassInterfaceWriter.cs
+++ b/src/dscom/writer/ClassInterfaceWriter.cs
@@ -14,7 +14,7 @@
 
 namespace dSPACE.Runtime.InteropServices.Writer;
 
-internal class ClassInterfaceWriter : DualInterfaceWriter
+internal sealed class ClassInterfaceWriter : DualInterfaceWriter
 {
     public ClassInterfaceWriter(Type sourceType, LibraryWriter libraryWriter, WriterContext context) : base(sourceType, libraryWriter, context)
     {

--- a/src/dscom/writer/ClassWriter.cs
+++ b/src/dscom/writer/ClassWriter.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Writer;
 
-internal class ClassWriter : TypeWriter
+internal sealed class ClassWriter : TypeWriter
 {
     public ClassWriter(Type sourceType, LibraryWriter libraryWriter, WriterContext context) : base(sourceType, libraryWriter, context)
     {

--- a/src/dscom/writer/DispInterfaceWriter.cs
+++ b/src/dscom/writer/DispInterfaceWriter.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Writer;
 
-internal class DispInterfaceWriter : InterfaceWriter
+internal sealed class DispInterfaceWriter : InterfaceWriter
 {
     public DispInterfaceWriter(Type sourceType, LibraryWriter libraryWriter, WriterContext context) : base(sourceType, libraryWriter, context)
     {

--- a/src/dscom/writer/EnumWriter.cs
+++ b/src/dscom/writer/EnumWriter.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Writer;
 
-internal class EnumWriter : TypeWriter
+internal sealed class EnumWriter : TypeWriter
 {
     public EnumWriter(Type sourceType, LibraryWriter libraryWriter, WriterContext context) : base(sourceType, libraryWriter, context)
     {

--- a/src/dscom/writer/HResultParamInfo.cs
+++ b/src/dscom/writer/HResultParamInfo.cs
@@ -18,7 +18,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Writer;
 
-internal class HResultParamInfo : ParameterInfo
+internal sealed class HResultParamInfo : ParameterInfo
 {
     public HResultParamInfo()
     {

--- a/src/dscom/writer/IUnknownInterfaceWriter.cs
+++ b/src/dscom/writer/IUnknownInterfaceWriter.cs
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Writer;
 
-internal class IUnknownInterfaceWriter : InterfaceWriter
+internal sealed class IUnknownInterfaceWriter : InterfaceWriter
 {
     public IUnknownInterfaceWriter(Type sourceType, LibraryWriter libraryWriter, WriterContext context) : base(sourceType, libraryWriter, context)
     {

--- a/src/dscom/writer/LibraryWriter.cs
+++ b/src/dscom/writer/LibraryWriter.cs
@@ -19,7 +19,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Writer;
 
-internal class LibraryWriter : BaseWriter
+internal sealed class LibraryWriter : BaseWriter
 {
     public LibraryWriter(Assembly assembly, WriterContext context) : base(context)
     {

--- a/src/dscom/writer/ParameterWriter.cs
+++ b/src/dscom/writer/ParameterWriter.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Writer;
 
-internal class ParameterWriter : ElemDescBasedWriter
+internal sealed class ParameterWriter : ElemDescBasedWriter
 {
     public ParameterWriter(MethodWriter methodWriter, ParameterInfo parameterInfo, WriterContext context, bool isTransformedOutParameter)
     : base(parameterInfo.ParameterType, parameterInfo, methodWriter.MethodInfo.ReflectedType!, methodWriter.InterfaceWriter.TypeInfo, context)

--- a/src/dscom/writer/PropertyGetMethodWriter.cs
+++ b/src/dscom/writer/PropertyGetMethodWriter.cs
@@ -16,7 +16,7 @@ using System.Reflection;
 
 namespace dSPACE.Runtime.InteropServices.Writer;
 
-internal class PropertyGetMethodWriter : PropertyMethodWriter
+internal sealed class PropertyGetMethodWriter : PropertyMethodWriter
 {
     public PropertyGetMethodWriter(InterfaceWriter interfaceWriter, MethodInfo methodInfo, WriterContext context, string methodName) : base(interfaceWriter, methodInfo, context, methodName)
     {

--- a/src/dscom/writer/PropertySetMethodWriter.cs
+++ b/src/dscom/writer/PropertySetMethodWriter.cs
@@ -16,7 +16,7 @@ using System.Reflection;
 
 namespace dSPACE.Runtime.InteropServices.Writer;
 
-internal class PropertySetMethodWriter : PropertyMethodWriter
+internal sealed class PropertySetMethodWriter : PropertyMethodWriter
 {
     public PropertySetMethodWriter(InterfaceWriter interfaceWriter, MethodInfo methodInfo, WriterContext context, string methodName) : base(interfaceWriter, methodInfo, context, methodName)
     {

--- a/src/dscom/writer/StructWriter.cs
+++ b/src/dscom/writer/StructWriter.cs
@@ -17,7 +17,7 @@ using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Writer;
 
-internal class StructWriter : TypeWriter
+internal sealed class StructWriter : TypeWriter
 {
     public StructWriter(Type sourceType, LibraryWriter libraryWriter, WriterContext context) : base(sourceType, libraryWriter, context)
     {


### PR DESCRIPTION
With #92 and the release of .NET 7, the Roslyn Compiler enables more
CA Rules (i.e. former FxCop rules). 

This Pull Request tidies the code to enable developers with a .NET 7 SDK installed
to produce builds without warnings.