### PR TITLE
fix: 98 registertypeforcomclients fails when type does not have a guidattribute

### DIFF
--- a/src/dscom/RegistrationServices.cs
+++ b/src/dscom/RegistrationServices.cs
@@ -49,7 +49,7 @@ public class RegistrationServices
     /// <param name="classContext">One of the <see cref="T:dSPACE.Runtime.InteropServices.ComTypes.RegistrationClassContext" /> values that indicates the context in which the executable code will be run.</param>
     /// <param name="flags">One of the <see cref="T:dSPACE.Runtime.InteropServices.ComTypes.RegistrationConnectionType" /> values that specifies how connections are made to the class object.</param>
     /// <returns>An integer that represents a cookie value.</returns>
-    /// <exception cref="T:System.ArgumentException">The <paramref name="type" /> parameter is <see langword="null" />.</exception>
+    /// <exception cref="T:System.ArgumentException">The <paramref name="type" /> parameter is <see langword="null" /> or not a valid type.</exception>
     /// <exception cref="T:System.ArgumentNullException">The <paramref name="type" /> parameter cannot be created.</exception>
     public int RegisterTypeForComClients(Type type, ComTypes.RegistrationClassContext classContext, ComTypes.RegistrationConnectionType flags)
     {
@@ -57,8 +57,7 @@ public class RegistrationServices
                     ?? type.Assembly.GetCustomAttributes<GuidAttribute>().FirstOrDefault()?.Value;
         if (value == null)
         {
-            // ToDo: We have to decide which Exception should be thrown here 
-            throw new InvalidComObjectException($"The given type {type} does not have a valid GUID attribute and cannot be registered.");
+            throw new ArgumentException($"The given type {type} does not have a valid GUID attribute.");
         }
 
         var guid = new Guid(value);

--- a/src/dscom/RegistrationServices.cs
+++ b/src/dscom/RegistrationServices.cs
@@ -53,7 +53,15 @@ public class RegistrationServices
     /// <exception cref="T:System.ArgumentNullException">The <paramref name="type" /> parameter cannot be created.</exception>
     public int RegisterTypeForComClients(Type type, ComTypes.RegistrationClassContext classContext, ComTypes.RegistrationConnectionType flags)
     {
-        var guid = new Guid(type.GetCustomAttributes<GuidAttribute>().First().Value);
+        var value = type.GetCustomAttributes<GuidAttribute>().FirstOrDefault()?.Value
+                    ?? type.Assembly.GetCustomAttributes<GuidAttribute>().FirstOrDefault()?.Value;
+        if (value == null)
+        {
+            // ToDo: We have to decide which Exception should be thrown here 
+            throw new InvalidComObjectException($"The given type {type} does not have a valid GUID attribute and cannot be registered.");
+        }
+
+        var guid = new Guid(value);
 
         var genericClassFactory = typeof(ClassFactory<>);
         Type[] typeArgs = { type };


### PR DESCRIPTION
Fixes #98 

Uses the GUID of the assembly as a fallback for registration if the type does not have a GUID attribute.