### PR TITLE
feat: Added the ability to register and unregister an entire assembly for COM

### DIFF
--- a/src/dscom/RegistrationServices.cs
+++ b/src/dscom/RegistrationServices.cs
@@ -382,7 +382,11 @@ public class RegistrationServices
 
         using var inProcServerKey = clsIdKey.CreateSubKey(RegistryKeys.InprocServer32);
 
-        inProcServerKey.SetValue(string.Empty, "mscoree.dll"); // TODO NET 6 does not provide mscoree - which assembly must be set here
+        // This should be the entry point for COM CoCreateInstance()
+        // Currently, there is no entry point for modern .NET 6 assemblies.
+        // This must be implemented in .NET 6 afterwards, if required.
+        // For .NET FX this would be mscoree.dll.
+        inProcServerKey.SetValue(string.Empty, string.Empty);
         inProcServerKey.SetValue(RegistryKeys.ThreadingModel, RegistryValues.ThreadingModel);
         inProcServerKey.SetValue(RegistryKeys.Class, type.FullName!);
         inProcServerKey.SetValue(RegistryKeys.Assembly, assemblyName);

--- a/src/dscom/RegistrationServices.cs
+++ b/src/dscom/RegistrationServices.cs
@@ -300,7 +300,7 @@ public class RegistrationServices
 
         using var inProcServerKey = clsIdKey.CreateSubKey(RegistryKeys.InprocServer32);
 
-        
+        inProcServerKey.SetValue(string.Empty, "mscoree.dll"); // TODO NET 6 does not provide mscoree - which assembly must be set here
         inProcServerKey.SetValue(RegistryKeys.ThreadingModel, RegistryValues.ThreadingModel);
         inProcServerKey.SetValue(RegistryKeys.Class, type.FullName!);
         inProcServerKey.SetValue(RegistryKeys.Assembly, assemblyName);

--- a/src/dscom/RegistrationServices.cs
+++ b/src/dscom/RegistrationServices.cs
@@ -11,8 +11,10 @@
 // limitations under the License.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Microsoft.Win32;
 
 namespace dSPACE.Runtime.InteropServices;
 
@@ -23,6 +25,35 @@ namespace dSPACE.Runtime.InteropServices;
 [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Compatibility to the mscorelib TypeLibConverter class")]
 public class RegistrationServices
 {
+    private static class RegistryKeys
+    {
+        private const string Implemented = nameof(Implemented);
+        private const string Component = nameof(Component);
+        private const string Categories = nameof(Categories);
+
+        public const string Record = nameof(Record);
+        public const string Class = nameof(Class);
+        public const string Assembly = nameof(Assembly);
+        public const string RuntimeVersion = nameof(RuntimeVersion);
+        public const string CodeBase = nameof(CodeBase);
+        public const string CLSID = nameof(CLSID);
+        public const string ThreadingModel = nameof(ThreadingModel);
+        public const string InprocServer32 = nameof(InprocServer32);
+        public const string ProgId = nameof(ProgId);
+
+        public const string ManagedCategoryGuid = "{62C8FE65-4EBB-45e7-B440-6E39B2CDBF29}"; // Found in mscorelib
+
+        public const string ImplementedCategories = $"{Implemented} {Categories}";
+        public const string ComponentCategories = $"{Component} {Categories}";
+    }
+
+    private static class RegistryValues
+    {
+        private const string Both = nameof(Both);
+
+        public const string ThreadingModel = Both;
+        public const string ManagedCategoryDescription = ".NET Category";
+    }
 
     /// <summary>Registers the specified type with COM using the specified GUID.</summary>
     /// <param name="type">The <see cref="T:System.Type" /> to be registered for use from COM.</param>
@@ -84,6 +115,283 @@ public class RegistrationServices
         if (hr < 0)
         {
             Marshal.ThrowExceptionForHR(hr);
+        }
+    }
+
+    /// <summary>
+    /// Registers the classes in a managed assembly to enable creation from COM.
+    /// </summary>
+    /// <param name="assembly">The assembly to register.</param>
+    /// <param name="registerCodeBase">If set to <c>true</c>, the code base will be added to the registry; otherwise not.</param>
+    /// <returns><c>true</c>, if at least one type from the registry has been registered.</returns>
+    public bool RegisterAssembly(Assembly assembly, bool registerCodeBase)
+    {
+        if (assembly is null)
+        {
+            throw new ArgumentNullException(nameof(assembly));
+        }
+
+        if (assembly.ReflectionOnly || assembly.IsDynamic)
+        {
+            throw new ArgumentException("Cannot register a ReflectionOnly or dynamic assembly");
+        }
+
+        var fullName = assembly.FullName;
+        if (fullName is null)
+        {
+            throw new ArgumentException("Cannot register an assembly without a full name");
+        }
+
+        string? codeBase = null;
+        if (registerCodeBase && assembly.Location is null)
+        {
+            // GetCodeBase/CodeBase is obsolete. Use Location instead
+            throw new ArgumentException("Cannot set code base on an assembly not providing a code base location.");
+        }
+        else if (registerCodeBase)
+        {
+            codeBase = assembly.Location;
+        }
+
+        var typesToRegister = GetComRegistratableTypes(assembly);
+
+        // Should be the same as RuntimeAssembly.GetVersion()
+        var assemblyVersion = assembly.GetCustomAttribute<AssemblyVersionAttribute>()?.Version ?? new Version().ToString();
+
+        var runtimeVersion = assembly.ImageRuntimeVersion;
+
+        foreach (var type in typesToRegister)
+        {
+            if (IsComRegistratableValueType(type))
+            {
+                RegisterValueType(type, fullName, assemblyVersion, codeBase, runtimeVersion);
+            }
+            else if (IsComType(type))
+            {
+                RegisterImportedComType(type, fullName, assemblyVersion, codeBase, runtimeVersion);
+            }
+            else
+            {
+                RegisterManagedType(type, fullName, assemblyVersion, codeBase, runtimeVersion);
+            }
+
+            // Skip: CustomRegistrationFunction
+        }
+
+        // Skip: PIA Regitration
+
+        return typesToRegister.Count > 0;
+    }
+
+    private static IReadOnlyCollection<Type> GetComRegistratableTypes(Assembly assembly)
+    {
+        static bool TypeMustBeRegistered(Type type)
+        {
+            if (type.IsClass || type.IsValueType)
+            {
+                return true;
+            }
+
+            if (type.IsAbstract)
+            {
+                return false;
+            }
+
+            var publicParameterlessCtor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public, null, Array.Empty<Type>(), null);
+            if (!type.IsValueType && publicParameterlessCtor is null)
+            {
+                return false;
+            }
+
+            return Marshal.IsTypeVisibleFromCom(type);
+        }
+
+        if (assembly is null)
+        {
+            throw new ArgumentNullException(nameof(assembly));
+        }
+
+        return assembly.GetExportedTypes().Where(TypeMustBeRegistered).ToArray();
+    }
+
+    private static bool IsComRegistratableValueType(Type type)
+    {
+        return type.IsValueType;
+    }
+
+    private static bool IsComType(Type type)
+    {
+        static Type? GetBaseComImportType(Type? currentType)
+        {
+            while (currentType != null && !currentType.IsImport)
+            {
+                currentType = currentType.BaseType;
+            }
+
+            return currentType;
+        }
+
+        if (type.IsCOMObject)
+        {
+            return false;
+        }
+
+        if (type.IsImport)
+        {
+            return true;
+        }
+
+        var parentComType = GetBaseComImportType(type);
+        return parentComType != null && MarshalExtension.GetClassInterfaceGuidForType(parentComType!) == MarshalExtension.GetClassInterfaceGuidForType(type);
+    }
+
+    private static void RegisterValueType(Type type, string assemblyName, string assemblyVersion, string? codeBase, string runtimeVersion)
+    {
+        if (type.FullName is null)
+        {
+            throw new ArgumentException("Cannot register a type without a full name");
+        }
+
+        var recordId = $"{{{MarshalExtension.GetClassInterfaceGuidForType(type).ToString().ToUpperInvariant()}}}";
+
+        using var recordRootKey = Registry.ClassesRoot.CreateSubKey(RegistryKeys.Record);
+        using var recordKey = recordRootKey.CreateSubKey(recordId);
+        using var recordVersionKey = recordKey.CreateSubKey(assemblyVersion);
+
+        recordVersionKey.SetValue(RegistryKeys.Class, type.FullName);
+
+        recordVersionKey.SetValue(RegistryKeys.Assembly, assemblyName);
+
+        recordVersionKey.SetValue(RegistryKeys.RuntimeVersion, runtimeVersion);
+
+        if (codeBase is not null)
+        {
+            recordVersionKey.SetValue(RegistryKeys.CodeBase, codeBase);
+        }
+    }
+
+    private static void RegisterManagedType(Type type, string assemblyName, string assemblyVersion, string? codeBase, string runtimeVersion)
+    {
+        if (type.FullName is null)
+        {
+            throw new ArgumentException("Cannot register a type without a full name");
+        }
+
+        var docString = type.FullName!;
+        var clsId = $"{{{Marshal.GenerateGuidForType(type).ToString().ToUpperInvariant()}}}";
+        var progId = Marshal.GenerateProgIdForType(type);
+
+        if (!string.IsNullOrWhiteSpace(progId))
+        {
+            using var typeNameKey = Registry.ClassesRoot.CreateSubKey(progId!);
+
+            typeNameKey.SetValue(string.Empty, docString);
+
+            using var progIdClsIdKey = typeNameKey.CreateSubKey(RegistryKeys.CLSID);
+
+            progIdClsIdKey.SetValue(string.Empty, clsId);
+        }
+
+        using var clsIdRootKey = Registry.ClassesRoot.CreateSubKey(RegistryKeys.CLSID);
+
+        using var clsIdKey = clsIdRootKey.CreateSubKey(clsId);
+
+        clsIdKey.SetValue(string.Empty, docString);
+
+        using var inProcServerKey = clsIdKey.CreateSubKey(RegistryKeys.InprocServer32);
+
+        
+        inProcServerKey.SetValue(RegistryKeys.ThreadingModel, RegistryValues.ThreadingModel);
+        inProcServerKey.SetValue(RegistryKeys.Class, type.FullName!);
+        inProcServerKey.SetValue(RegistryKeys.Assembly, assemblyName);
+        inProcServerKey.SetValue(RegistryKeys.RuntimeVersion, runtimeVersion);
+        if (codeBase is not null)
+        {
+            inProcServerKey.SetValue(RegistryKeys.CodeBase, codeBase!);
+        }
+
+        using var versionSubKey = inProcServerKey.CreateSubKey(assemblyVersion);
+        {
+            versionSubKey.SetValue(RegistryKeys.Class, type.FullName!);
+            versionSubKey.SetValue(RegistryKeys.Assembly, assemblyName);
+            versionSubKey.SetValue(RegistryKeys.RuntimeVersion, runtimeVersion);
+            if (codeBase is not null)
+            {
+                versionSubKey.SetValue(RegistryKeys.CodeBase, codeBase!);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(progId))
+        {
+            using var progIdKey = clsIdKey.CreateSubKey(RegistryKeys.ProgId);
+
+            progIdKey.SetValue(string.Empty, progId!);
+
+        }
+
+        using var implementedCategoryKey = clsIdKey.CreateSubKey(RegistryKeys.ImplementedCategories);
+
+        using var managedCategoryKeyForImplemented = implementedCategoryKey.CreateSubKey(RegistryKeys.ManagedCategoryGuid);
+
+        using var componentCategoryKey = Registry.ClassesRoot.CreateSubKey(RegistryKeys.ComponentCategories);
+        using var managedCategoryKey = componentCategoryKey.CreateSubKey(RegistryKeys.ManagedCategoryGuid);
+
+        var key0 = Convert.ToString(0, CultureInfo.InvariantCulture);
+        var value = managedCategoryKey.GetValue(key0);
+        if (value is not null && value.GetType() != typeof(string))
+        {
+            managedCategoryKey.DeleteValue(key0);
+            managedCategoryKey.SetValue(key0, RegistryValues.ManagedCategoryDescription);
+        }
+        else if (value is not null)
+        {
+            var keyValue = (string)value;
+            if (!StringComparer.InvariantCulture.Equals(keyValue, RegistryValues.ManagedCategoryDescription))
+            {
+                managedCategoryKey.SetValue(key0, RegistryValues.ManagedCategoryDescription);
+            }
+        }
+        else
+        {
+            managedCategoryKey.SetValue(key0, RegistryValues.ManagedCategoryDescription);
+        }
+    }
+
+    private static void RegisterImportedComType(Type type, string assemblyName, string assemblyVersion, string? codeBase, string runtimeVersion)
+    {
+        if (type.FullName is null)
+        {
+            throw new ArgumentException("Cannot register a type without a full name");
+        }
+
+        var clsId = $"{{{Marshal.GenerateGuidForType(type).ToString().ToUpperInvariant()}}}";
+
+        using var clsIdRootKey = Registry.ClassesRoot.CreateSubKey(RegistryKeys.CLSID);
+
+        using var clsIdKey = clsIdRootKey.CreateSubKey(clsId);
+
+        using var inProcServerKey = clsIdKey.CreateSubKey(RegistryKeys.InprocServer32);
+
+        inProcServerKey.SetValue(RegistryKeys.Class, type.FullName!);
+
+        inProcServerKey.SetValue(RegistryKeys.Assembly, assemblyName);
+
+        inProcServerKey.SetValue(RegistryKeys.RuntimeVersion, runtimeVersion);
+
+
+        if (codeBase is not null)
+        {
+            inProcServerKey.SetValue(RegistryKeys.CodeBase, codeBase!);
+        }
+
+        using var versionSubKey = inProcServerKey.CreateSubKey(assemblyVersion);
+
+        versionSubKey.SetValue(RegistryKeys.Class, type.FullName!);
+        versionSubKey.SetValue(RegistryKeys.Assembly, assemblyName);
+        versionSubKey.SetValue(RegistryKeys.RuntimeVersion, runtimeVersion);
+        if (codeBase is not null)
+        {
+            versionSubKey.SetValue(RegistryKeys.CodeBase, codeBase!);
         }
     }
 }

--- a/src/dscom/RegistrationServices.cs
+++ b/src/dscom/RegistrationServices.cs
@@ -311,7 +311,6 @@ public class RegistrationServices
         }
 
         using var versionSubKey = inProcServerKey.CreateSubKey(assemblyVersion);
-        {
             versionSubKey.SetValue(RegistryKeys.Class, type.FullName!);
             versionSubKey.SetValue(RegistryKeys.Assembly, assemblyName);
             versionSubKey.SetValue(RegistryKeys.RuntimeVersion, runtimeVersion);
@@ -319,7 +318,6 @@ public class RegistrationServices
             {
                 versionSubKey.SetValue(RegistryKeys.CodeBase, codeBase!);
             }
-        }
 
         if (!string.IsNullOrWhiteSpace(progId))
         {


### PR DESCRIPTION
In .NET FullFramework the `RegistrationServices` class provided both - a `RegisterAssembly` and an `UnregisterAssembly` method.

Based on the original implementation, this pull requests adds a reimplementation of the registration und deregistration functionality for dscom.

Limitations:

- InProc Registration only will take place, if a [comhost](https://learn.microsoft.com/en-us/dotnet/core/native-interop/expose-components-to-com) assembly is present.
- No CustomRegisterFunction Or CustomUnRegisterFunction Attribute support
- No PrimaryInteropAssembly Support

Reviewer:

- [ ] Sebastian Osterbrink (@SOsterbrink)
- [ ] Mark Lechtermann (@marklechtermann)
- [ ] Matthias Nissen (@matthiasnissen)