### PR TITLE
fix: Add Names to MsBuild Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ The build task consumes the following [items](https://learn.microsoft.com/en-us/
 | DsComTlbExportTlbReferences  | Referenced type library files.                           |
 | DsComTlbExportReferencePaths | Directories containing type libraries to use for export. |
 | DsComTlbExportAssemblyPaths  | Assemblies to add for the export.                        |
+| DsComTlbAliasNames           | Names to use as aliases for types with aliases.          |
 
 ### Example
 

--- a/src/dscom.build/TlbExport.cs
+++ b/src/dscom.build/TlbExport.cs
@@ -88,6 +88,11 @@ public sealed class TlbExport : Microsoft.Build.Utilities.Task
     /// </summary>
     public ITaskItem[] AssemblyPaths { get; set; } = Array.Empty<ITaskItem>();
 
+    /// <summary>
+    /// Gets or sets the names to map to a new resolved name.
+    /// </summary>
+    public string[] Names { get; set; } = Array.Empty<string>();
+
     /// <inheritdoc cref="Task.Execute()" />
     public override bool Execute()
     {
@@ -170,6 +175,8 @@ public sealed class TlbExport : Microsoft.Build.Utilities.Task
         checks.VerifyFilesPresent(settings.TLBReference, false, ref result);
         checks.VerifyDirectoriesPresent(settings.TLBRefpath, false, ref result);
         checks.VerifyFilesPresent(settings.ASMPath, false, ref result);
+
+        settings.Names = Names ?? Array.Empty<string>();
 
         // run conversion, if result has been successful.
         result = result && _context.ConvertAssemblyToTypeLib(settings, Log);

--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Task.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Task.targets
@@ -45,6 +45,7 @@
       SourceAssemblyFile="$(_DsComExportTypeLibraryAssemblyFile)"
       TypeLibraryReferences="@(DsComTlbExportTlbReferences)"
       TypeLibraryReferencePaths="@(DsComTlbExportReferencePaths)"
-      AssemblyPaths="@(DsComTlbExportAssemblyPaths)" />
+      AssemblyPaths="@(DsComTlbExportAssemblyPaths)"
+      Names="@(DsComTlbAliasNames)" />
   </Target>
 </Project>

--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
@@ -44,6 +44,7 @@
       <_DsComTypeLibraryReferencePaths Condition="@(DsComTlbExportReferencePaths->Count()) &gt; 0">--tlbrefpath "@(DsComTlbExportReferencePaths, '"--tlbrefpath "')"</_DsComTypeLibraryReferencePaths>
       <_DsComAssemblyReferences Condition="@(_DsComTlbExportAssemblyPathsWithoutHintPath->Count()) &gt; 0">--asmpath "@(_DsComTlbExportAssemblyPathsWithoutHintPath, '"--asmpath "')"</_DsComAssemblyReferences>
       <_DsComAssemblyReferences Condition="@(_DsComTlbExportAssemblyPathsWithHintPath->Count()) &gt; 0">--asmpath "@(_DsComTlbExportAssemblyPathsWithHintPath->GetMetadata('HintPath'), '"--asmpath "')"</_DsComAssemblyReferences>
+      <_DsComAliasNames Condition="@(DsComTlbAliasNames->Count() &gt; 0)">--names @(DsComTlbAliasNames, --names)</_DsComAliasNames>
       <_DsComArguments>tlbexport</_DsComArguments>
       <_DsComArguments Condition="'$(DsComTypeLibraryUniqueId)' != '' AND '$(DsComTypeLibraryUniqueId)' != '$([System.Guid]::Empty.ToString())'">$(_DsComArguments) --overridetlbid "$(DsComTypeLibraryUniqueId)"</_DsComArguments>
       <_DsComArguments Condition="'$(DsComToolVerbose)' == 'true'"> $(_DsComArguments) --verbose</_DsComArguments>
@@ -51,6 +52,7 @@
       <_DsComArguments> $(_DsComArguments) $(_DsComTypeLibraryReferences)</_DsComArguments>
       <_DsComArguments> $(_DsComArguments) $(_DsComTypeLibraryReferencePaths)</_DsComArguments>
       <_DsComArguments> $(_DsComArguments) $(_DsComExportTypeLibraryAssemblyFile)</_DsComArguments>
+      <_DsComArguments> $(_DsComArguments) $(_DsComAliasNames)</_DsComArguments>
       <_DsComArguments> $(_DsComArguments) --out $(_DsComExportTypeLibraryTargetFile)</_DsComArguments>
     </PropertyGroup>
     

--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.props
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.props
@@ -42,5 +42,6 @@
     <DsComTlbExportTlbReferences Remove="*" />
     <DsComTlbExportReferencePaths Remove="*" />
     <DsComTlbExportAssemblyPaths Remove="*" />
+    <DsComTlbAliasNames Remove="*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
In #131 names were introduced in form of an alias. The names parameter was already supported before
but ignored by the MsBuild tasks.

This will add the names to the MsBuild tasks