### PR TITLE
fix: MsBuild Task is failing

### DIFF
--- a/examples/32bit/scripts/msbuild-acceptance-test.cmd
+++ b/examples/32bit/scripts/msbuild-acceptance-test.cmd
@@ -11,6 +11,8 @@ IF NOT EXIST %root%\_packages MKDIR _packages
 XCOPY /Y /I /C /F .\src\dscom\bin\Release\*.nupkg _packages\
 XCOPY /Y /I /C /F .\src\dscom.build\bin\Release\*.nupkg _packages\
 
+dotnet nuget locals all --clear
+
 POPD
 
 PUSHD %~dp0\..\comtestdotnet

--- a/examples/outproc/scripts/msbuild-acceptance-test.cmd
+++ b/examples/outproc/scripts/msbuild-acceptance-test.cmd
@@ -11,6 +11,8 @@ IF NOT EXIST %root%\_packages MKDIR _packages
 XCOPY /Y /I /C /F .\src\dscom\bin\Release\*.nupkg _packages\
 XCOPY /Y /I /C /F .\src\dscom.build\bin\Release\*.nupkg _packages\
 
+dotnet nuget locals all --clear
+
 POPD
 
 PUSHD %~dp0\..

--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
@@ -44,7 +44,7 @@
       <_DsComTypeLibraryReferencePaths Condition="@(DsComTlbExportReferencePaths->Count()) &gt; 0">--tlbrefpath "@(DsComTlbExportReferencePaths, '"--tlbrefpath "')"</_DsComTypeLibraryReferencePaths>
       <_DsComAssemblyReferences Condition="@(_DsComTlbExportAssemblyPathsWithoutHintPath->Count()) &gt; 0">--asmpath "@(_DsComTlbExportAssemblyPathsWithoutHintPath, '"--asmpath "')"</_DsComAssemblyReferences>
       <_DsComAssemblyReferences Condition="@(_DsComTlbExportAssemblyPathsWithHintPath->Count()) &gt; 0">--asmpath "@(_DsComTlbExportAssemblyPathsWithHintPath->GetMetadata('HintPath'), '"--asmpath "')"</_DsComAssemblyReferences>
-      <_DsComAliasNames Condition="@(DsComTlbAliasNames->Count() &gt; 0)">--names @(DsComTlbAliasNames, --names)</_DsComAliasNames>
+      <_DsComAliasNames Condition="@(DsComTlbAliasNames->Count()) &gt; 0">--names @(DsComTlbAliasNames, --names)</_DsComAliasNames>
       <_DsComArguments>tlbexport</_DsComArguments>
       <_DsComArguments Condition="'$(DsComTypeLibraryUniqueId)' != '' AND '$(DsComTypeLibraryUniqueId)' != '$([System.Guid]::Empty.ToString())'">$(_DsComArguments) --overridetlbid "$(DsComTypeLibraryUniqueId)"</_DsComArguments>
       <_DsComArguments Condition="'$(DsComToolVerbose)' == 'true'"> $(_DsComArguments) --verbose</_DsComArguments>


### PR DESCRIPTION
The msbuild task is currently failing (cf. #138). This is due to a syntax error introduced in #136.

The acceptance test should have noticed this, but seems to reuse packages from the cache. This should be fixed by explicitely clearing the cache.

Closes #138

Fixes #136 