### PR TITLE
fix: Whitespace in AssemblyPath

### DIFF
--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
@@ -53,7 +53,7 @@
       <_DsComArguments> $(_DsComArguments) $(_DsComTypeLibraryReferencePaths)</_DsComArguments>
       <_DsComArguments> $(_DsComArguments) $(_DsComExportTypeLibraryAssemblyFile)</_DsComArguments>
       <_DsComArguments> $(_DsComArguments) $(_DsComAliasNames)</_DsComArguments>
-      <_DsComArguments> $(_DsComArguments) --out $(_DsComExportTypeLibraryTargetFile)</_DsComArguments>
+      <_DsComArguments> $(_DsComArguments) --out "$(_DsComExportTypeLibraryTargetFile)"</_DsComArguments>
     </PropertyGroup>
     
     <Message Importance="High" Text="Calling dscom.exe to export type library" />


### PR DESCRIPTION
If the output path contains whitespace, these will be taken into account.

Closes "Build fails, when project path contains whitespaces" #148