### PR TITLE
fix: ensure that the correct .NET version is used

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,9 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.404
+          
+      - name: Ensure that dotnet version is used
+        run: dotnet new globaljson --sdk-version 6.0.404 --roll-forward latestFeature
 
       - name: Get .net version
         run: dotnet --version


### PR DESCRIPTION
select the .NET version which is used while publishing a new release