### PR TITLE
perf: Improve performance by introducing caches to hotspots

### DIFF
--- a/src/dscom/TypeInfoResolver.cs
+++ b/src/dscom/TypeInfoResolver.cs
@@ -25,6 +25,8 @@ internal sealed class TypeInfoResolver : ITypeLibCache
 
     private readonly Dictionary<Guid, ITypeInfo> _types = new();
 
+    private readonly Dictionary<Type, ITypeInfo?> _resolvedTypeInfos = new();
+
     public WriterContext WriterContext { get; }
 
     public TypeInfoResolver(WriterContext writerContext)
@@ -67,6 +69,11 @@ internal sealed class TypeInfoResolver : ITypeLibCache
 
     public ITypeInfo? ResolveTypeInfo(Type type)
     {
+        if (_resolvedTypeInfos.TryGetValue(type, out var typeInfo))
+        {
+            return typeInfo;
+        }
+
         ITypeInfo? retval;
         if (type.FullName == "System.Collections.IEnumerator")
         {
@@ -126,6 +133,7 @@ internal sealed class TypeInfoResolver : ITypeLibCache
                 }
             }
         }
+        _resolvedTypeInfos[type] = retval;
         return retval;
     }
 

--- a/src/dscom/writer/MethodWriter.cs
+++ b/src/dscom/writer/MethodWriter.cs
@@ -60,12 +60,20 @@ internal class MethodWriter : BaseWriter
         return retVal;
     }
 
+    private bool? _isComVisible;
+
     protected virtual bool IsComVisible
     {
         get
         {
+            if (_isComVisible != null)
+            {
+                return _isComVisible.Value;
+            }
+
             var methodAttribute = MethodInfo.GetCustomAttribute<ComVisibleAttribute>();
-            return methodAttribute == null || methodAttribute.Value;
+            _isComVisible = methodAttribute == null || methodAttribute.Value;
+            return _isComVisible.Value;
         }
     }
 

--- a/src/dscom/writer/PropertyMethodWriter.cs
+++ b/src/dscom/writer/PropertyMethodWriter.cs
@@ -26,12 +26,20 @@ internal class PropertyMethodWriter : MethodWriter
         MemberInfo = _propertyInfo!;
     }
 
+    private bool? _isComVisible;
+
     protected override bool IsComVisible
     {
         get
         {
+            if (_isComVisible != null)
+            {
+                return _isComVisible.Value;
+            }
+
             var propertyAttribute = MemberInfo.GetCustomAttribute<ComVisibleAttribute>();
-            return (propertyAttribute == null || propertyAttribute.Value) && base.IsComVisible;
+            _isComVisible = (propertyAttribute == null || propertyAttribute.Value) && base.IsComVisible;
+            return _isComVisible.Value;
         }
     }
 


### PR DESCRIPTION
This change can improve performance for large assemblies/type libraries by a factor of 2 or more (>100 in extreme cases).

Added caches for:
- TypeInfoResolver.ResolveTypeInfo(Type)
- MethodWriter.IsComVisible
- PropertyMethodWriter.IsComVisible
