### PR TITLE
Show type and member names in warning messages

### DIFF
--- a/src/dscom/writer/ElemDescBasedWriter.cs
+++ b/src/dscom/writer/ElemDescBasedWriter.cs
@@ -46,7 +46,7 @@ internal class ElemDescBasedWriter : BaseWriter
 
         if (Type.GetUnderlayingType().IsGenericType)
         {
-            Context.LogWarning("Warning: Type library exporter encountered a generic type instance in a signature. Generic code may not be exported to COM.", unchecked(HRESULT.TLBX_E_GENERICINST_SIGNATURE));
+            Context.LogWarning($"Warning: Type library exporter encountered generic type {Type.GetUnderlayingType()} in a signature while writing type {ParentType}. Generic code may not be exported to COM.", unchecked(HRESULT.TLBX_E_GENERICINST_SIGNATURE));
         }
 
         var unrefedType = Type.IsByRef ? Type.GetElementType()! : Type;
@@ -62,7 +62,7 @@ internal class ElemDescBasedWriter : BaseWriter
                     marshasinfo += $" SafeArraySubType: {TypeProvider.MarshalAsAttribute!.SafeArraySubType}";
                 }
             }
-            Context.LogWarning($"Type library exporter warning processing '{Type.Name}'{marshasinfo}. Warning: The method or field has an invalid managed/unmanaged type combination, check the MarshalAs directive.", unchecked(HRESULT.TLBX_E_BAD_NATIVETYPE));
+            Context.LogWarning($"Type library exporter warning processing '{Type}'{marshasinfo}. Warning: The method or field has an invalid managed/unmanaged type combination, check the MarshalAs directive.", unchecked(HRESULT.TLBX_E_BAD_NATIVETYPE));
         }
     }
 

--- a/src/dscom/writer/EnumWriter.cs
+++ b/src/dscom/writer/EnumWriter.cs
@@ -54,9 +54,9 @@ internal sealed class EnumWriter : TypeWriter
             varDesc.wVarFlags = 0;
 
             TypeInfo.AddVarDesc(index, varDesc)
-                .ThrowIfFailed($"Failed to add variable description for enum {Name}.");
+                .ThrowIfFailed($"Failed to add variable description for enum {SourceType}.");
             TypeInfo.SetVarName(index, Context.NameResolver.GetMappedName(field, $"{Name}_{field.Name}"))
-                .ThrowIfFailed($"Failed to set variable name for enum {Name}.");
+                .ThrowIfFailed($"Failed to set variable name {field.Name} for enum {SourceType}.");
             index++;
         }
 

--- a/src/dscom/writer/MethodWriter.cs
+++ b/src/dscom/writer/MethodWriter.cs
@@ -191,23 +191,23 @@ internal class MethodWriter : BaseWriter
             names = GetNamesForParameters().ToArray();
 
             typeInfo.AddFuncDesc((uint)funcIndex, funcDesc.Value)
-                .ThrowIfFailed($"Failed to add function description for {MethodInfo.Name}.");
+                .ThrowIfFailed($"Failed to add function description for {MethodInfo.DeclaringType}.{MethodInfo.Name}().");
 
             typeInfo.SetFuncAndParamNames((uint)funcIndex, names, (uint)names.Length)
-                .ThrowIfFailed($"Failed to set function and parameter names for {MethodInfo.Name}.");
+                .ThrowIfFailed($"Failed to set function and parameter names for {MethodInfo.DeclaringType}.{MethodInfo.Name}().");
 
             var description = MethodInfo.GetCustomAttribute<System.ComponentModel.DescriptionAttribute>();
             if (description != null)
             {
                 typeInfo.SetFuncDocString((uint)funcIndex, description.Description)
-                    .ThrowIfFailed($"Failed to set function documentation string for {MethodInfo.Name}.");
+                    .ThrowIfFailed($"Failed to set function documentation string for {MethodInfo.DeclaringType}.{MethodInfo.Name}().");
             }
 
             if (memidCreated == 0 && InvokeKind == INVOKEKIND.INVOKE_FUNC)
             {
                 //Function has been forced as property (default member handling)
                 typeInfo.SetFuncCustData((uint)funcIndex, new Guid(Guids.GUID_Function2Getter), 1)
-                    .ThrowIfFailed($"Failed to set function custom data for {MethodInfo.Name}.");
+                    .ThrowIfFailed($"Failed to set function custom data for {MethodInfo.DeclaringType}.{MethodInfo.Name}().");
             }
 
         }

--- a/src/dscom/writer/ParameterWriter.cs
+++ b/src/dscom/writer/ParameterWriter.cs
@@ -83,7 +83,7 @@ internal sealed class ParameterWriter : ElemDescBasedWriter
         base.ReportEvent();
         if (!ParameterIsResolvable && Type.GetUnderlayingType().IsInterface)
         {
-            Context.LogWarning($"Warning: Type library exporter could not find the type library for {Type.GetUnderlayingType().Name}.  IUnknown was substituted for the interface.", HRESULT.TLBX_I_USEIUNKNOWN);
+            Context.LogWarning($"Warning: Type library exporter could not find the type library for {Type.GetUnderlayingType()} while writing member {ParentType}.{ParameterInfo.Member.Name}. IUnknown was substituted for the interface.", HRESULT.TLBX_I_USEIUNKNOWN);
         }
     }
 

--- a/src/dscom/writer/TypeWriter.cs
+++ b/src/dscom/writer/TypeWriter.cs
@@ -76,7 +76,7 @@ internal abstract class TypeWriter : BaseWriter
         if (typeLib != null)
         {
             typeLib.CreateTypeInfo(Context.NameResolver.GetMappedName(SourceType, Name), TypeKind, out var createTypeInfo)
-                    .ThrowIfFailed($"Failed to create type info for {Name}.");
+                    .ThrowIfFailed($"Failed to create type info {Name} for type {SourceType}.");
 
             _createTypeInfo2 = (ICreateTypeInfo2)createTypeInfo;
 


### PR DESCRIPTION
Warning messages now contain the names of the relevant types and members. This makes analysis of a warning easier.