### PR TITLE
fix: "ambiguous match" error when exporting multiple indexers

### DIFF
--- a/src/dscom.demo/assembly3/IDemoInterfaceComInvisible.cs
+++ b/src/dscom.demo/assembly3/IDemoInterfaceComInvisible.cs
@@ -26,3 +26,12 @@ public interface IDemoInterfaceComVisible
 {
     void DoSomething(IDemoInterfaceComInvisible param);
 }
+
+[ComVisible(true)]
+public interface IDemoInterfaceIndexerInvisible
+{
+    public string this[int x] { get; }
+
+    [ComVisible(false)]
+    public string this[string s] { get; }
+}

--- a/src/dscom/writer/PropertyMethodWriter.cs
+++ b/src/dscom/writer/PropertyMethodWriter.cs
@@ -22,7 +22,7 @@ internal class PropertyMethodWriter : MethodWriter
     private readonly PropertyInfo? _propertyInfo;
     public PropertyMethodWriter(InterfaceWriter interfaceWriter, MethodInfo methodInfo, WriterContext context, string methodName) : base(interfaceWriter, methodInfo, context, methodName)
     {
-        _propertyInfo = methodInfo.DeclaringType!.GetProperty(GetPropertyName());
+        _propertyInfo = methodInfo.DeclaringType!.GetProperties().First(p => p.GetGetMethod() == methodInfo || p.GetSetMethod() == methodInfo);
         MemberInfo = _propertyInfo!;
     }
 


### PR DESCRIPTION
If an interface contains multiple indexers, but only one is ComVisible = true, dscom throws an unexpected exception "Ambiguous match found".

This is because dscom searched for the indexer property via its special name "get_Item". However, if multiple indexers exist this throws an exception.

Instead of searching for the propery by name we search by its getter or setter methods.