### PR TITLE
fix: unloadable app context

### DIFF
--- a/src/dscom.client/AssemblyResolver.cs
+++ b/src/dscom.client/AssemblyResolver.cs
@@ -74,7 +74,6 @@ internal sealed class AssemblyResolver : IDisposable
             if (disposing)
             {
                 _context.Resolving -= Context_Resolving;
-                _context.Unload();
             }
 
             _disposedValue = true;

--- a/src/dscom.client/AssemblyResolver.cs
+++ b/src/dscom.client/AssemblyResolver.cs
@@ -28,7 +28,7 @@ internal sealed class AssemblyResolver : IDisposable
     internal AssemblyResolver(TypeLibConverterOptions options)
     {
         Options = options;
-        _context = new AssemblyLoadContext("dscom", true);
+        _context = new AssemblyLoadContext("dscom");
         _context.Resolving += Context_Resolving;
     }
 


### PR DESCRIPTION
fix: #207 Set isCollectible to false in the AssemblyLoadContext creation 
This will make the AssemblyLoadContext impossible to unload during the runtime of the client and should allow C++ CLI assemblies to be loaded. 

resolves #207 