### PR TITLE
fix: Changed WorkingDirectory to $(OutDir) as default and $(OutputPath) as fallback

### DIFF
--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
@@ -52,7 +52,7 @@
       <_DsComArguments> $(_DsComArguments) $(_DsComAssemblyReferences)</_DsComArguments>
       <_DsComArguments> $(_DsComArguments) $(_DsComTypeLibraryReferences)</_DsComArguments>
       <_DsComArguments> $(_DsComArguments) $(_DsComTypeLibraryReferencePaths)</_DsComArguments>
-      <_DsComArguments> $(_DsComArguments) $(_DsComExportTypeLibraryAssemblyFile)</_DsComArguments>
+      <_DsComArguments> $(_DsComArguments) "$(_DsComExportTypeLibraryAssemblyFile)"</_DsComArguments>
       <_DsComArguments> $(_DsComArguments) $(_DsComAliasNames)</_DsComArguments>
       <_DsComArguments Condition="'$(DsComOverideLibraryName)' != ''"> $(_DsComArguments) --overridename "$(DsComOverideLibraryName)"</_DsComArguments>
       <_DsComArguments> $(_DsComArguments) --out "$(_DsComExportTypeLibraryTargetFile)"</_DsComArguments>
@@ -63,7 +63,7 @@
     <Message Importance="High" Text="Calling dscom.exe to export type library" />
     <Message Importance="Low" Text="Using arguments '$(_DsComArguments)' to call dscom" />
     
-    <Exec Command="$(_DsComToolsFileDir)dscom.exe $(_DsComArguments)"
+    <Exec Command='"$(_DsComToolsFileDir)dscom.exe" $(_DsComArguments)'
           ConsoleToMsBuild="true" 
           StdErrEncoding="UTF-8"
           StdOutEncoding="UTF-8"

--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
@@ -56,6 +56,8 @@
       <_DsComArguments> $(_DsComArguments) $(_DsComAliasNames)</_DsComArguments>
       <_DsComArguments Condition="'$(DsComOverideLibraryName)' != ''"> $(_DsComArguments) --overridename "$(DsComOverideLibraryName)"</_DsComArguments>
       <_DsComArguments> $(_DsComArguments) --out "$(_DsComExportTypeLibraryTargetFile)"</_DsComArguments>
+	    <_DsComWorkingDir>$(OutDir)</_DsComWorkingDir> 
+	    <_DsComWorkingDir Condition="$(_DsComWorkingDir) == ''">$(OutputPath)</_DsComWorkingDir> 
     </PropertyGroup>
     
     <Message Importance="High" Text="Calling dscom.exe to export type library" />
@@ -66,7 +68,7 @@
           StdErrEncoding="UTF-8"
           StdOutEncoding="UTF-8"
           IgnoreExitCode="false"
-          WorkingDirectory="$(OutputPath)" />
+          WorkingDirectory="$(_DsComWorkingDir)" />
 
     <Warning Code="DSCOM001" Text="Could not find the type library at the following location: '$(_DsComExportTypeLibraryTargetFile)'" Condition="!Exists('$(_DsComExportTypeLibraryTargetFile)')" />
   </Target>


### PR DESCRIPTION
Exec WorkingDirectory should be `$(OutDir)` as default and `$(OutputPath)` as fallback.
`$(OutputPath)` might not work on large complex solutions.

See https://github.com/dotnet/msbuild/blob/f914c9bfb613d32edb658b803c7fe046f9ee3c37/src/Tasks/Microsoft.Common.CurrentVersion.targets#L107-L122

_'OutDir and OutputPath are distinguished for legacy reasons, and OutDir should be used if at all possible.'_


Experienced this error in my solution where `$(OutDir)` is used.

```
Calling dscom.exe to export type library
P:\code\packages_installed\dspace.runtime.interopservices.buildtasks\1.7.0\build\dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets(64,5): error MSB6003: The specified task executable "cmd.exe" could not be run. System.IO.DirectoryNotFoundException: The working directory "bin\x64\Debug\net8.0-windows\win-x64\" does not exist.
P:\code\packages_installed\dspace.runtime.interopservices.buildtasks\1.7.0\build\dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets(64,5): error MSB6003:    at Microsoft.Build.Tasks.Exec.GetWorkingDirectory()
P:\code\packages_installed\dspace.runtime.interopservices.buildtasks\1.7.0\build\dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets(64,5): error MSB6003:    at Microsoft.Build.Utilities.ToolTask.GetProcessStartInfo(String pathToTool, String commandLineCommands, String responseFileSwitch)
P:\code\packages_installed\dspace.runtime.interopservices.buildtasks\1.7.0\build\dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets(64,5): error MSB6003:    at Microsoft.Build.Utilities.ToolTask.ExecuteTool(String pathToTool, String responseFileCommands, String commandLineCommands)
P:\code\packages_installed\dspace.runtime.interopservices.buildtasks\1.7.0\build\dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets(64,5): error MSB6003:    at Microsoft.Build.Tasks.Exec.ExecuteTool(String pathToTool, String responseFileCommands, String commandLineCommands)
P:\code\packages_installed\dspace.runtime.interopservices.buildtasks\1.7.0\build\dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets(64,5): error MSB6003:    at Microsoft.Build.Utilities.ToolTask.Execute()
```

Also there were quotation marks missing causing an exit code 9009 (file not found) on calling the dscom tool if it is located in a path containing spaces.

This Pull Request fixes these issues.