### PR TITLE
259 error could not load file or assembly presentationframework on tlbexport regression in 160

### DIFF
--- a/src/dscom.demo/assembly5/ExplodeyBaseClass.cs
+++ b/src/dscom.demo/assembly5/ExplodeyBaseClass.cs
@@ -4,7 +4,7 @@ namespace dSPACE.Runtime.InteropServices.DemoAssembly5;
 
 public class ExplodeyBaseClass : UserControl
 {
-    private class PrivateImplementationDetails
+    private sealed class PrivateImplementationDetails
     {
         // required to reproduce #259
     }

--- a/src/dscom.demo/assembly5/ExplodeyBaseClass.cs
+++ b/src/dscom.demo/assembly5/ExplodeyBaseClass.cs
@@ -4,4 +4,8 @@ namespace dSPACE.Runtime.InteropServices.DemoAssembly5;
 
 public class ExplodeyBaseClass : UserControl
 {
+    private class PrivateImplementationDetails
+    {
+        // required to reproduce #259
+    }
 }

--- a/src/dscom/writer/LibraryWriter.cs
+++ b/src/dscom/writer/LibraryWriter.cs
@@ -97,11 +97,6 @@ internal sealed class LibraryWriter : BaseWriter
 
         foreach (var type in types)
         {
-            if (type == null || type.Namespace is null)
-            {
-                continue;
-            }
-
             var comVisibleAttribute = type.GetCustomAttribute<ComVisibleAttribute>();
 
             if (typesAreVisibleForComByDefault && comVisibleAttribute != null && !comVisibleAttribute.Value)
@@ -114,7 +109,13 @@ internal sealed class LibraryWriter : BaseWriter
                 continue;
             }
 
+
             if (!type.IsPublic && !type.IsNestedPublic)
+            {
+                continue;
+            }
+
+            if (type.Namespace is null)
             {
                 continue;
             }


### PR DESCRIPTION
fix: #259 Exception on trying to load namespace attribute 

Moved the check for the namespace attribute after the check for COM visibility, because classes and libraries which are `ComVisible = false` will be skipped and should not receive further checks. 

