### PR TITLE
Added CLI based task overridable properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,17 +306,16 @@ The build task can be parameterized with the following [properties](https://lear
 
 | **Name**                                       | **Description**                                                                                |
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| _DsComTlbExt                                   | Extension of the resulting type library. <br /> Default Value: `.tlb`                                                                          |
-| _DsComForceToolUsage                           | Use DsCom Exe files to create the TLB <br/> Default value: `false`                                                         | false                                         |
-| DsComTypeLibraryUniqueId                       | Overwrite the library UUID <br/> Default Value: Empty Guid                                    |
-| DsComOverideLibraryName                        | Overwrite the IDL name of the library. <br/> Default Value: Empty string   | 
-| DsComRegisterTypeLibrariesAfterBuild           | Use regasm call after the build to register type library after the build <br/> Default value: `false`                                         |
-| DsComTlbExportAutoAddReferences                | Add referenced assemblies automatically to type libraries <br/> Default value: `true`                                          |
-| DsComTlbExportIncludeReferencesWithoutHintPath | If a `Reference` assembly does not provide a `HintPath` Metadata, the item spec shall be task. <br/> Default value: `false`                                         |
-| _DsComExportTypeLibraryTargetFile              | Path to the resulting file. <br/> Default value: `$(TargetDir)\$(TargetName)$(_DsComTlbExt)` * |
-| _DsComExportTypeLibraryAssemblyFile            | Path to the source assembly file. <br/> Default value: `$(TargetPath)` *                             |
-| DsComTypeLibraryEmbedAfterBuild                | Embeds the generated type library into the source assembly file. <br /> Default value: `false`                                         |
-*) This value cannot be overridden.
+| _DsComTlbExt                                   | Extension of the resulting type library. <br /> Default Value: `.tlb`                          |
+| _DsComForceToolUsage                           | Use DsCom Exe files to create the TLB <br/> Default value: `false`                             |
+| DsComTypeLibraryUniqueId                       | Overwrite the library UUID <br/> Default Value: Empty Guid                                     |
+| DsComOverideLibraryName                        | Overwrite the IDL name of the library. <br/> Default Value: Empty string                       | 
+| DsComRegisterTypeLibrariesAfterBuild           | Use regasm call after the build to register type library after the build <br/> Default value: `false` |
+| DsComTlbExportAutoAddReferences                | Add referenced assemblies automatically to type libraries <br/> Default value: `true`          |
+| DsComTlbExportIncludeReferencesWithoutHintPath | If a `Reference` assembly does not provide a `HintPath` Metadata, the item spec shall be task. <br/> Default value: `false` |
+| DsComExportTypeLibraryTargetFile               | Path to the resulting file. <br/> Default value: `$(TargetDir)\$(TargetName)$(_DsComTlbExt)` * |
+| DsComExportTypeLibraryAssemblyFile             | Path to the source assembly file. <br/> Default value: `$(TargetPath)` *                       |
+| DsComTypeLibraryEmbedAfterBuild                | Embeds the generated type library into the source assembly file. <br /> Default value: `false` |
 
 The build task consumes the following [items](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-items?view=vs-2022):
 
@@ -326,6 +325,19 @@ The build task consumes the following [items](https://learn.microsoft.com/en-us/
 | DsComTlbExportReferencePaths | Directories containing type libraries to use for export. |
 | DsComTlbExportAssemblyPaths  | Assemblies to add for the export.                        |
 | DsComTlbAliasNames           | Names to use as aliases for types with aliases.          |
+
+The CLI based task consumes these additional [properties](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-properties?view=vs-2022):
+
+| **Name**                     | **Description**                                          |
+| ---------------------------- | -------------------------------------------------------- |
+| DsComToolVerbose             | Enables `verbose` option.                                |
+| DsComToolSilent              | Enables `silent` option.                                 |
+
+The CLI based task consumes these additional [items](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-items?view=vs-2022):
+
+| **Name**                     | **Description**                                          |
+| ---------------------------- | -------------------------------------------------------- |
+| DsComToolSilence             | Enables `silence` option for the given warnings          |
 
 ### Example
 

--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
@@ -46,10 +46,12 @@
       <_DsComAssemblyReferences Condition="@(_DsComTlbExportAssemblyPathsWithoutHintPath->Count()) &gt; 0">--asmpath "@(_DsComTlbExportAssemblyPathsWithoutHintPath, '" --asmpath "')"</_DsComAssemblyReferences>
       <_DsComAssemblyReferences Condition="@(_DsComTlbExportAssemblyPathsWithHintPath->Count()) &gt; 0">--asmpath "@(_DsComTlbExportAssemblyPathsWithHintPath->GetMetadata('HintPath'), '" --asmpath "')"</_DsComAssemblyReferences>
       <_DsComAliasNames Condition="@(DsComTlbAliasNames->Count()) &gt; 0">--names @(DsComTlbAliasNames, --names)</_DsComAliasNames>
+      <_DsComToolSilence Condition="@(DsComToolSilence->Count()) &gt; 0">--silence "@(DsComToolSilence, '" --silence "')"</_DsComToolSilence>
       <_DsComArguments>tlbexport</_DsComArguments>
       <_DsComArguments> $(_DsComArguments) "$(_DsComExportTypeLibraryAssemblyFile)"</_DsComArguments>
       <_DsComArguments Condition="'$(DsComTypeLibraryUniqueId)' != '' AND '$(DsComTypeLibraryUniqueId)' != '$([System.Guid]::Empty.ToString())'">$(_DsComArguments) --overridetlbid "$(DsComTypeLibraryUniqueId)"</_DsComArguments>
       <_DsComArguments Condition="'$(DsComToolVerbose)' == 'true'"> $(_DsComArguments) --verbose</_DsComArguments>
+      <_DsComArguments Condition="'$(DsComToolSilent)' == 'true'"> $(_DsComArguments) --silent</_DsComArguments>
       <!-- Handles .NET 4.8 which would be embedded into the same output assembly -->
       <_DsComArguments Condition="'$(DsComTypeLibraryEmbedAfterBuild)' == 'true' AND $(ComHostIntermediatePath) == ''"> $(_DsComArguments) --embed</_DsComArguments>
       <!-- Handles .NET 5+ which would be embedded into the generated comhost DLL -->
@@ -58,11 +60,12 @@
       <_DsComArguments> $(_DsComArguments) $(_DsComTypeLibraryReferences)</_DsComArguments>
       <_DsComArguments> $(_DsComArguments) $(_DsComTypeLibraryReferencePaths)</_DsComArguments>
       <_DsComArguments> $(_DsComArguments) $(_DsComAliasNames)</_DsComArguments>
+      <_DsComArguments> $(_DsComArguments) $(_DsComToolSilence)</_DsComArguments>
       <_DsComArguments Condition="'$(DsComOverideLibraryName)' != ''"> $(_DsComArguments) --overridename "$(DsComOverideLibraryName)"</_DsComArguments>
       <_DsComArguments Condition="'$(DsComTlbExportCreateMissingDependentTlbs)' != ''"> $(_DsComArguments) --createmissingdependenttlbs $(DsComTlbExportCreateMissingDependentTlbs)</_DsComArguments>
       <_DsComArguments> $(_DsComArguments) --out "$(_DsComExportTypeLibraryTargetFile)"</_DsComArguments>
-	    <_DsComWorkingDir>$(OutDir)</_DsComWorkingDir> 
-	    <_DsComWorkingDir Condition="$(_DsComWorkingDir) == ''">$(OutputPath)</_DsComWorkingDir> 
+      <_DsComWorkingDir>$(OutDir)</_DsComWorkingDir> 
+      <_DsComWorkingDir Condition="$(_DsComWorkingDir) == ''">$(OutputPath)</_DsComWorkingDir> 
     </PropertyGroup>
     
     <Message Importance="High" Text="Calling dscom.exe to export type library" />

--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.targets
@@ -29,9 +29,9 @@
   <!-- Export settings. -->
   <PropertyGroup>
     <!-- Set file path of target file -->
-    <_DsComExportTypeLibraryTargetFile>$(TargetDir)\$(TargetName)$(_DsComTlbExt)</_DsComExportTypeLibraryTargetFile>
+    <_DsComExportTypeLibraryTargetFile Condition="$(DsComExportTypeLibraryTargetFile) == ''">$(TargetDir)\$(TargetName)$(_DsComTlbExt)</_DsComExportTypeLibraryTargetFile>
     <!-- Set file path of source file -->
-    <_DsComExportTypeLibraryAssemblyFile>$(TargetPath)</_DsComExportTypeLibraryAssemblyFile>
+    <_DsComExportTypeLibraryAssemblyFile Condition="$(DsComExportTypeLibraryAssemblyFile) = ''">$(TargetPath)</_DsComExportTypeLibraryAssemblyFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.targets
@@ -31,7 +31,7 @@
     <!-- Set file path of target file -->
     <_DsComExportTypeLibraryTargetFile Condition="$(DsComExportTypeLibraryTargetFile) == ''">$(TargetDir)\$(TargetName)$(_DsComTlbExt)</_DsComExportTypeLibraryTargetFile>
     <!-- Set file path of source file -->
-    <_DsComExportTypeLibraryAssemblyFile Condition="$(DsComExportTypeLibraryAssemblyFile) = ''">$(TargetPath)</_DsComExportTypeLibraryAssemblyFile>
+    <_DsComExportTypeLibraryAssemblyFile Condition="$(DsComExportTypeLibraryAssemblyFile) == ''">$(TargetPath)</_DsComExportTypeLibraryAssemblyFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix for [#289](https://github.com/dspace-group/dscom/issues/289)

Add overridable properties for _DsComExportTypeLibraryTargetFile and _DsComExportTypeLibraryAssemblyFile