### PR TITLE
fix: C++/CLI mixed mode cannot be used as reference assemblies

### DIFF
--- a/src/dscom.client/AssemblyResolver.cs
+++ b/src/dscom.client/AssemblyResolver.cs
@@ -24,7 +24,7 @@ internal sealed class AssemblyResolver : AssemblyLoadContext, IDisposable
 {
     private bool _disposedValue;
 
-    internal AssemblyResolver(TypeLibConverterOptions options) : base("dscom", isCollectible: true)
+    internal AssemblyResolver(TypeLibConverterOptions options) : base("dscom", isCollectible: false)
     {
         Options = options;
         Resolving += Context_Resolving;
@@ -72,7 +72,6 @@ internal sealed class AssemblyResolver : AssemblyLoadContext, IDisposable
             if (disposing)
             {
                 Resolving -= Context_Resolving;
-                Unload();
             }
 
             _disposedValue = true;


### PR DESCRIPTION
dscom crashes, when a C++/CLI Mixed mode assembly is used as a reference.

This is due to the fact, that dotnet cannot load C++/CLI mixed moded assemblies into a collectible AssemblyLoadContext.

Closes #292 

For details refer to https://github.com/dotnet/runtime/issues/72237