### PR TITLE
Demand-load tlbs instead of always loading them

### DIFF
--- a/src/dscom/writer/LibraryWriter.cs
+++ b/src/dscom/writer/LibraryWriter.cs
@@ -61,7 +61,6 @@ internal sealed class LibraryWriter : BaseWriter
             }
 
             Context.TypeInfoResolver.AddTypeLib((ITypeLib)typeLib);
-            Context.TypeInfoResolver.AddAdditionalTypeLibs();
 
             if (!string.IsNullOrEmpty(Context.Options.Out))
             {


### PR DESCRIPTION
Closes #310 

I'm not sure if this is the best way to fix this.

It feels like `TypeLibExporterNotifySink.ResolveRef` is a better location. However, it does not have access to `_additionalLibs` in `TypeInfoResolver`.