### PR TITLE
feat: Support for regasm.exe functionalities

### DIFF
--- a/src/dscom.client/AssemblyResolver.cs
+++ b/src/dscom.client/AssemblyResolver.cs
@@ -22,25 +22,20 @@ namespace dSPACE.Runtime.InteropServices;
 /// </summary>
 internal sealed class AssemblyResolver : AssemblyLoadContext, IDisposable
 {
+    private readonly string[] _paths;
+
     private bool _disposedValue;
 
-    internal AssemblyResolver(TypeLibConverterOptions options) : base("dscom", isCollectible: options.ShouldEmbed())
+    internal AssemblyResolver(string[] paths, bool isCollectible)
+        : base("dscom", isCollectible)
     {
-        Options = options;
+        _paths = paths;
         Resolving += Context_Resolving;
     }
 
     private Assembly? Context_Resolving(AssemblyLoadContext context, AssemblyName name)
     {
-        var dir = Path.GetDirectoryName(Options.Assembly);
-
-        var asmPaths = Options.ASMPath;
-        if (Directory.Exists(dir))
-        {
-            asmPaths = asmPaths.Prepend(dir).ToArray();
-        }
-
-        foreach (var path in asmPaths)
+        foreach (var path in _paths)
         {
             var dllToLoad = Path.Combine(path, $"{name.Name}.dll");
             if (File.Exists(dllToLoad))
@@ -62,8 +57,6 @@ internal sealed class AssemblyResolver : AssemblyLoadContext, IDisposable
     {
         return LoadFromAssemblyPath(path);
     }
-
-    public TypeLibConverterOptions Options { get; }
 
     private void Dispose(bool disposing)
     {

--- a/src/dscom.client/Program.cs
+++ b/src/dscom.client/Program.cs
@@ -15,6 +15,7 @@
 using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
 using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -27,58 +28,68 @@ public static class ConsoleApp
     public static int Main(string[] args)
     {
         var tlbexportCommand = new Command("tlbexport", "Export the assembly to the specified type library") {
-                new Argument<string>("Assembly", "File name of assembly to parse"),
-                new Option<string>(new[] {"--out", "/out"}, description: "File name of type library to be produced"),
-                new Option<string[]>(new[] {"--tlbreference", "/tlbreference"}, description: "Type library used to resolve references", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
-                new Option<string[]>(new[] {"--tlbrefpath", "/tlbrefpath"}, description: "Path used to resolve referenced type libraries", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
-                new Option<string[]>(new[] {"--asmpath", "/asmpath"}, description: "Look for assembly references here", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
-                new Option<bool>(new[] {"--silent", "/silent"}, description: "Suppresses all output except for errors"),
-                new Option<string[]>(new[] {"--silence", "/silence"}, description: "Suppresses output for the given warning (Can not be used with /silent)", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
-                new Option<bool>(new[] {"--verbose", "/verbose"}, description: "Detailed log output"),
-                new Option<string[]>(new[] {"--names", "/names"}, description: "A file in which each line specifies the capitalization of a name in the type library.", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
-                new Option<string>(new[] { "--overridename", "/overridename"}, description: "Overwrites the library name"),
-                new Option<Guid>(new[] {"--overridetlbid", "/overridetlbid"}, description: "Overwrites the library id"),
-                new Option<bool?>(new[] {"--createmissingdependenttlbs", "/createmissingdependenttlbs"}, description: "Generate missing type libraries for referenced assemblies. (default true)"),
-                new Option<string?>(new[] { "--embed", "/embed"}, () => TypeLibConverterOptions.NotSpecifiedViaCommandLineArgumentsDefault, description: "Embeds type library into the assembly. (default: false)") { Arity = ArgumentArity.ZeroOrOne },
-                new Option<ushort>(new[] {"--index", "/index"}, () => 1, description: "If the switch --embed is specified, the index indicates the resource ID to be used for the embedded type library. Must be a number between 1 and 65535. Ignored if --embed not present. (default 1)")
-            };
+            new Argument<string>("Assembly", "File name of assembly to parse"),
+            new Option<string>(new[] {"--out", "/out"}, description: "File name of type library to be produced"),
+            new Option<string[]>(new[] {"--tlbreference", "/tlbreference"}, description: "Type library used to resolve references", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
+            new Option<string[]>(new[] {"--tlbrefpath", "/tlbrefpath"}, description: "Path used to resolve referenced type libraries", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
+            new Option<string[]>(new[] {"--asmpath", "/asmpath"}, description: "Look for assembly references here", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
+            new Option<bool>(new[] {"--silent", "/silent"}, description: "Suppresses all output except for errors"),
+            new Option<string[]>(new[] {"--silence", "/silence"}, description: "Suppresses output for the given warning (Can not be used with /silent)", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
+            new Option<bool>(new[] {"--verbose", "/verbose"}, description: "Detailed log output"),
+            new Option<string[]>(new[] {"--names", "/names"}, description: "A file in which each line specifies the capitalization of a name in the type library.", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
+            new Option<string>(new[] { "--overridename", "/overridename"}, description: "Overwrites the library name"),
+            new Option<Guid>(new[] {"--overridetlbid", "/overridetlbid"}, description: "Overwrites the library id"),
+            new Option<bool?>(new[] {"--createmissingdependenttlbs", "/createmissingdependenttlbs"}, description: "Generate missing type libraries for referenced assemblies. (default true)"),
+            new Option<string?>(new[] { "--embed", "/embed"}, () => TypeLibConverterOptions.NotSpecifiedViaCommandLineArgumentsDefault, description: "Embeds type library into the assembly. (default: false)") { Arity = ArgumentArity.ZeroOrOne },
+            new Option<ushort>(new[] {"--index", "/index"}, () => 1, description: "If the switch --embed is specified, the index indicates the resource ID to be used for the embedded type library. Must be a number between 1 and 65535. Ignored if --embed not present. (default 1)")
+        };
 
         var tlbdumpCommand = new Command("tlbdump", "Dump a type library")
-            {
-                new Argument<string>("TypeLibrary", "File name of type library"),
-                new Option<string>(new[] {"--out", "/out"}, description: "File name of the output"),
-                new Option<string[]>(new[] {"--tlbreference", "/tlbreference"}, description: "Type library used to resolve references", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
-                new Option<string[]>(new[] {"--tlbrefpath", "/tlbrefpath"}, description: "Path used to resolve referenced type libraries", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
-                new Option<string[]>(new[] {"--filterregex", "/filterregex"}, description: "Regex to filter the output", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
-            };
+        {
+            new Argument<string>("TypeLibrary", "File name of type library"),
+            new Option<string>(new[] {"--out", "/out"}, description: "File name of the output"),
+            new Option<string[]>(new[] {"--tlbreference", "/tlbreference"}, description: "Type library used to resolve references", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
+            new Option<string[]>(new[] {"--tlbrefpath", "/tlbrefpath"}, description: "Path used to resolve referenced type libraries", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
+            new Option<string[]>(new[] {"--filterregex", "/filterregex"}, description: "Regex to filter the output", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
+        };
 
         var tlbregisterCommand = new Command("tlbregister", "Register a type library")
-            {
-                new Argument<string>("TypeLibrary", "File name of type library"),
-                new Option<bool>(new[] {"--foruser", "/foruser"}, description: "Registered for use only by the calling user identity."),
-            };
+        {
+            new Argument<string>("TypeLibrary", "File name of type library"),
+            new Option<bool>(new[] {"--foruser", "/foruser"}, description: "Registered for use only by the calling user identity."),
+        };
 
         var tlbunregisterCommand = new Command("tlbunregister", "Unregister a type library")
-            {
-                new Argument<string>("TypeLibrary", "File name of type library"),
-                new Option<bool>(new[] {"--foruser", "/foruser"}, description: "Registered for use only by the calling user identity."),
-            };
+        {
+            new Argument<string>("TypeLibrary", "File name of type library"),
+            new Option<bool>(new[] {"--foruser", "/foruser"}, description: "Registered for use only by the calling user identity."),
+        };
 
         var tlbembedCommand = new Command("tlbembed", "Embeds a source type library into a target file")
-            {
-                new Argument<string>("SourceTypeLibrary","File name of type library"),
-                new Argument<string>("TargetAssembly", "File name of target assembly to receive the type library as a resource"),
-                new Option<ushort>(new[] {"--index", "/index"}, () => 1, description:"Index to use for resource ID for the type library. If omitted, defaults to 1. Must be a positive integer from 1 to 65535.")
-            };
+        {
+            new Argument<string>("SourceTypeLibrary","File name of type library"),
+            new Argument<string>("TargetAssembly", "File name of target assembly to receive the type library as a resource"),
+            new Option<ushort>(new[] {"--index", "/index"}, () => 1, description:"Index to use for resource ID for the type library. If omitted, defaults to 1. Must be a positive integer from 1 to 65535.")
+        };
+
+        var registerCommand = new Command("asmregister", "register assembly")
+        {
+            new Argument<string>("TargetAssembly", "File name of target assembly to receive the type library as a resource"),
+            new Option<string[]>(new[] {"--asmpath", "/asmpath"}, description: "Look for assembly references here", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
+            new Option<string[]>(new[] { "--tblrefpath", "/tblrefpath"}, description: "Look for type library references here", getDefaultValue: () =>  Array.Empty<string>()) { Arity =  ArgumentArity.ZeroOrMore},
+            new Option<bool>(new[] {"--TLB", "/TLB"}, description: "Will create and register a typelibrary for the given assembly"),
+            new Option<bool>(new[] {"--codebase", "/codebase"}, description: "Will register the assembly with codebase"),
+        };
 
         var rootCommand = new RootCommand
-            {
-                tlbexportCommand,
-                tlbdumpCommand,
-                tlbregisterCommand,
-                tlbunregisterCommand,
-                tlbembedCommand
-            };
+        {
+            tlbexportCommand,
+            tlbdumpCommand,
+            tlbregisterCommand,
+            tlbunregisterCommand,
+            tlbembedCommand,
+            registerCommand
+        };
 
         rootCommand.Description = $"dSPACE COM tools ({(Environment.Is64BitProcess ? "64Bit" : "32Bit")})";
 
@@ -87,6 +98,7 @@ public static class ConsoleApp
         ConfigureTLBRegisterHandler(tlbregisterCommand);
         ConfigureTLBUnRegisterHandler(tlbunregisterCommand);
         ConfigureTLBEmbedHandler(tlbembedCommand);
+        ConfigureAsmRegisterHandler(registerCommand);
 
         return rootCommand.Invoke(args);
     }
@@ -153,6 +165,61 @@ public static class ConsoleApp
         tlbembedCommand.Handler = CommandHandler.Create<TypeLibEmbedderSettings>((settings) => TypeLibEmbedder.EmbedTypeLib(settings));
     }
 
+    /// <summary>
+    /// Will register an assembly like regasm.exe
+    /// </summary>
+    /// <param name="registerCommand"></param>
+    /// <exception cref="FileNotFoundException"></exception>
+    private static void ConfigureAsmRegisterHandler(Command registerCommand)
+    {
+        registerCommand.Handler = CommandHandler.Create<RegisterAssemblySettings>(
+            (options) =>
+            {
+                try
+                {
+                    var paths = options.ASMPath.Append(Path.GetDirectoryName(options.TargetAssembly)).ToArray();
+
+                    using var assemblyResolver = new AssemblyResolver(paths!, false);
+
+                    if (!File.Exists(options.TargetAssembly))
+                    {
+                        throw new FileNotFoundException($"File {options.TargetAssembly} not found.");
+                    }
+
+                    var assembly = assemblyResolver.LoadAssembly(options.TargetAssembly);
+
+                    var lypeLibConvertOptions = new TypeLibConverterOptions()
+                    {
+                        ASMPath = paths!,
+
+                        TLBRefpath = options.TLBRefpath,
+
+                        Assembly = options.TargetAssembly,
+
+                        Out = Path.ChangeExtension(options.TargetAssembly, ".tlb")
+                    };
+
+                    if (options.TLB)
+                    {
+                        // Export TLB
+                        ExportTypeLibraryImpl(assembly, lypeLibConvertOptions);
+
+                        // Register TLB
+                        RegisterTypeLib(lypeLibConvertOptions.Out);
+                    }
+
+                    var registrationService = new RegistrationServices();
+                    registrationService.RegisterAssembly(assembly, options.Codebase);
+
+                    return 0;
+                }
+                catch (Exception e)
+                {
+                    return HandleException(e, "Failed to register assembly.");
+                }
+            });
+    }
+
     private static void ConfigureTLBExportHandler(Command tlbexportCommand)
     {
         tlbexportCommand.Handler = CommandHandler.Create<TypeLibConverterOptions>((options) =>
@@ -191,7 +258,15 @@ public static class ConsoleApp
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ExportTypeLibraryImpl(TypeLibConverterOptions options, out WeakReference weakRef)
     {
-        using var assemblyResolver = new AssemblyResolver(options);
+        var dir = Path.GetDirectoryName(options.Assembly);
+
+        var asmPaths = options.ASMPath;
+        if (Directory.Exists(dir))
+        {
+            asmPaths = asmPaths.Prepend(dir).ToArray();
+        }
+
+        using var assemblyResolver = new AssemblyResolver(asmPaths, options.ShouldEmbed());
         weakRef = new WeakReference(assemblyResolver, trackResurrection: true);
         if (!File.Exists(options.Assembly))
         {
@@ -199,6 +274,14 @@ public static class ConsoleApp
         }
 
         var assembly = assemblyResolver.LoadAssembly(options.Assembly);
+
+        ExportTypeLibraryImpl(assembly, options);
+    }
+
+    private static void ExportTypeLibraryImpl(
+        Assembly assembly,
+        TypeLibConverterOptions options)
+    {
         var typeLibConverter = new TypeLibConverter();
         var nameResolver = options.Names.Length > 0 ? NameResolver.Create(options.Names) : NameResolver.Create(assembly);
         var typeLib = typeLibConverter.ConvertAssemblyToTypeLib(assembly, options, new TypeLibExporterNotifySink(options, nameResolver));

--- a/src/dscom/RegisterAssemblySettings.cs
+++ b/src/dscom/RegisterAssemblySettings.cs
@@ -15,7 +15,7 @@
 namespace dSPACE.Runtime.InteropServices;
 
 /// <summary>
-///  Represents the settings used by <see cref="TypeLibEmbedder"/>.
+///  Represents the settings used for registration of an assembly (like RegAsm.exe)
 /// </summary>
 public class RegisterAssemblySettings
 {
@@ -25,7 +25,7 @@ public class RegisterAssemblySettings
     public string TargetAssembly { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets a path to a directory with assemblies.
+    /// Specifies a directory containing assembly references.
     /// </summary>
     public string[] ASMPath { get; set; } = Array.Empty<string>();
 
@@ -40,7 +40,13 @@ public class RegisterAssemblySettings
     public bool TLB { get; set; }
 
     /// <summary>
-    /// Gets or sets the flag for registration with codebase
+    /// Gets or sets the flag for creating the codebase entry in the registry.
     /// </summary>
     public bool Codebase { get; set; }
+
+    /// <summary>
+    /// Gets or sets the flag for deregistration of the assembly
+    /// </summary>
+    public bool Unregister { get; set; }
+
 }

--- a/src/dscom/RegisterAssemblySettings.cs
+++ b/src/dscom/RegisterAssemblySettings.cs
@@ -1,0 +1,46 @@
+// Copyright 2022 dSPACE GmbH, Mark Lechtermann, Matthias Nissen and Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace dSPACE.Runtime.InteropServices;
+
+/// <summary>
+///  Represents the settings used by <see cref="TypeLibEmbedder"/>.
+/// </summary>
+public class RegisterAssemblySettings
+{
+    /// <summary>
+    /// Gets or sets target assembly path.
+    /// </summary>
+    public string TargetAssembly { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a path to a directory with assemblies.
+    /// </summary>
+    public string[] ASMPath { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets or sets a path to a directory with type libraries.
+    /// </summary>
+    public string[] TLBRefpath { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Get or sets the flag for creating a type library
+    /// </summary>
+    public bool TLB { get; set; }
+
+    /// <summary>
+    /// Gets or sets the flag for registration with codebase
+    /// </summary>
+    public bool Codebase { get; set; }
+}

--- a/src/dscom/RegistrationServices.cs
+++ b/src/dscom/RegistrationServices.cs
@@ -283,6 +283,18 @@ public class RegistrationServices
     {
         static bool TypeMustBeRegistered(Type type)
         {
+            // Only public types are com visible
+            if (!type.IsPublic && !type.IsNestedPublic && !type.IsByRef)
+            {
+                return false;
+            }
+
+            // Type could be defined as not com visible
+            if (!type.IsComVisible())
+            {
+                return false;
+            }
+
             if (type.IsGenericType)
             {
                 return false;

--- a/src/dscom/RegistrationServices.cs
+++ b/src/dscom/RegistrationServices.cs
@@ -205,9 +205,11 @@ public class RegistrationServices
 
         var typesToRegister = GetComRegistratableTypes(assembly);
 
-        // Should be the same as RuntimeAssembly.GetVersion()
-        var assemblyVersion = assembly.GetCustomAttribute<AssemblyVersionAttribute>()?.Version ?? new Version().ToString();
+        var assemblyVersion = assembly.GetCustomAttribute<AssemblyVersionAttribute>()?.Version
+            ?? assembly.GetName().Version?.ToString()
+            ?? new Version().ToString();
 
+        // Should be the same as RuntimeAssembly.GetVersion()
         var runtimeVersion = assembly.ImageRuntimeVersion;
 
         foreach (var type in typesToRegister)
@@ -255,7 +257,9 @@ public class RegistrationServices
         var typesToUnregister = GetComRegistratableTypes(assembly);
 
         // Should be the same as RuntimeAssembly.GetVersion()
-        var assemblyVersion = assembly.GetCustomAttribute<AssemblyVersionAttribute>()?.Version ?? new Version().ToString();
+        var assemblyVersion = assembly.GetCustomAttribute<AssemblyVersionAttribute>()?.Version
+            ?? assembly.GetName().Version?.ToString()
+            ?? new Version().ToString();
 
         foreach (var type in typesToUnregister)
         {
@@ -283,18 +287,6 @@ public class RegistrationServices
     {
         static bool TypeMustBeRegistered(Type type)
         {
-            // Only public types are com visible
-            if (!type.IsPublic && !type.IsNestedPublic && !type.IsByRef)
-            {
-                return false;
-            }
-
-            // Type could be defined as not com visible
-            if (!type.IsComVisible())
-            {
-                return false;
-            }
-
             if (type.IsGenericType)
             {
                 return false;
@@ -309,11 +301,6 @@ public class RegistrationServices
             if (!type.IsValueType && publicParameterlessCtor is null)
             {
                 return false;
-            }
-
-            if (type.IsClass || type.IsValueType)
-            {
-                return true;
             }
 
             return Marshal.IsTypeVisibleFromCom(type);
@@ -380,7 +367,7 @@ public class RegistrationServices
 
         if (codeBase is not null)
         {
-            recordVersionKey.SetValue(RegistryKeys.CodeBase, codeBase);
+            recordVersionKey.SetValue(RegistryKeys.CodeBase, $"file:///{codeBase}");
         }
     }
 
@@ -461,23 +448,27 @@ public class RegistrationServices
         var comHostFile = GetComHost(codeBase);
         if (null != comHostFile)
         {
-            inProcServerKey.SetValue(string.Empty, string.Empty);
+            // regsvr32.exe sets the path to the comhost assembly here
+            inProcServerKey.SetValue(string.Empty, comHostFile);
             inProcServerKey.SetValue(RegistryKeys.ThreadingModel, RegistryValues.ThreadingModel);
+
+            // these key-value-pairs are the same like the registration by regasm
             inProcServerKey.SetValue(RegistryKeys.Class, type.FullName!);
             inProcServerKey.SetValue(RegistryKeys.Assembly, assemblyName);
             inProcServerKey.SetValue(RegistryKeys.RuntimeVersion, runtimeVersion);
             if (codeBase is not null)
             {
-                inProcServerKey.SetValue(RegistryKeys.CodeBase, codeBase!);
+                inProcServerKey.SetValue(RegistryKeys.CodeBase, $"file:///{codeBase}");
             }
 
             using var versionSubKey = inProcServerKey.CreateSubKey(assemblyVersion);
+            versionSubKey.SetValue(string.Empty, string.Empty);
             versionSubKey.SetValue(RegistryKeys.Class, type.FullName!);
             versionSubKey.SetValue(RegistryKeys.Assembly, assemblyName);
             versionSubKey.SetValue(RegistryKeys.RuntimeVersion, runtimeVersion);
             if (codeBase is not null)
             {
-                versionSubKey.SetValue(RegistryKeys.CodeBase, codeBase!);
+                versionSubKey.SetValue(RegistryKeys.CodeBase, $"file:///{codeBase}");
             }
         }
 
@@ -486,7 +477,6 @@ public class RegistrationServices
             using var progIdKey = clsIdKey.CreateSubKey(RegistryKeys.ProgId);
 
             progIdKey.SetValue(string.Empty, progId!);
-
         }
 
         using var implementedCategoryKey = clsIdKey.CreateSubKey(RegistryKeys.ImplementedCategories);
@@ -634,8 +624,8 @@ public class RegistrationServices
         var clsId = $"{{{Marshal.GenerateGuidForType(type).ToString().ToUpperInvariant()}}}";
         var progId = Marshal.GenerateProgIdForType(type);
 
-        using var clsIdRootKey = Registry.ClassesRoot.OpenSubKey(RegistryKeys.CLSID, true);
-
+        using var rootKey = GetTargetRootKey();
+        using var clsIdRootKey = rootKey.OpenSubKey(RegistryKeys.CLSID, true);
         using var clsIdKey = clsIdRootKey?.OpenSubKey(clsId, true);
 
         clsIdKey?.DeleteValue(string.Empty, false);
@@ -644,6 +634,7 @@ public class RegistrationServices
 
         using var versionSubKey = inProcServerKey?.OpenSubKey(assemblyVersion, true);
 
+        versionSubKey?.DeleteValue(string.Empty, false);
         versionSubKey?.DeleteValue(RegistryKeys.Class, false);
         versionSubKey?.DeleteValue(RegistryKeys.Assembly, false);
         versionSubKey?.DeleteValue(RegistryKeys.RuntimeVersion, false);
@@ -755,7 +746,7 @@ public class RegistrationServices
 
         if (codeBase is not null)
         {
-            inProcServerKey.SetValue(RegistryKeys.CodeBase, codeBase!);
+            inProcServerKey.SetValue(RegistryKeys.CodeBase, $"file:///{codeBase}");
         }
 
         using var versionSubKey = inProcServerKey.CreateSubKey(assemblyVersion);
@@ -765,7 +756,7 @@ public class RegistrationServices
         versionSubKey.SetValue(RegistryKeys.RuntimeVersion, runtimeVersion);
         if (codeBase is not null)
         {
-            versionSubKey.SetValue(RegistryKeys.CodeBase, codeBase!);
+            versionSubKey.SetValue(RegistryKeys.CodeBase, $"file:///{codeBase}");
         }
     }
 
@@ -833,11 +824,12 @@ public class RegistrationServices
         {
             return Registry.ClassesRoot;
         }
+        else
+        {
+            using var software = Registry.CurrentUser.CreateSubKey(RegistryKeys.Software, true);
 
-        var root = Registry.CurrentUser;
-        using var software = root.CreateSubKey(RegistryKeys.Software, true);
-        var classes = software.CreateSubKey(RegistryKeys.Software, true);
-        return classes;
+            return software.CreateSubKey(RegistryKeys.Classes, true);
+        }
     }
 
     private static bool CanWriteGlobalRegistry()


### PR DESCRIPTION
Hello,

I have the problem that I have a .NET 8.0 assembly that I need to register as COM to make it available for VB6 (for Debugging). So far, I have used dscom32.exe for this purpose, both to create and register the TLB.

With regsvr32.exe, I encounter an issue where the application does not work with my assembly because there are classes that implement a generic interface. However, these interfaces are not COM-visible and are only necessary for internal wrapping.

To address this, I created the command 'asmregister', which is intended to handle the tasks of regasm.exe.

This Pull-Request is more like a Proposal for implementing this.

Furthermore i got the problem, that after this procedure i can't run the VB6 Application, because there is a mismatch in the interface. I think that VB6 can not connected the CLSID given by RegisterAssembly and the registered TypeLibrary. Perhaps you got an idea.