### PR TITLE
test: Removed tlb and dll writing for demo and analysis

### DIFF
--- a/src/dscom.test/BaseTest.cs
+++ b/src/dscom.test/BaseTest.cs
@@ -52,8 +52,7 @@ public class BaseTest
 
         var name = GenerateAssemblyName(assemblyName, filepath, callerName);
 
-        var typeLibPath = Path.Combine(Dir, $"{name}.tlb");
-        return new DynamicAssemblyBuilder(name, assemblyBuilder, typeLibPath);
+        return new DynamicAssemblyBuilder(name, assemblyBuilder);
     }
 
     internal DynamicAssemblyBuilder CreateAssembly(AssemblyName name,

--- a/src/dscom.test/builder/DynamicAssemblyBuilder.cs
+++ b/src/dscom.test/builder/DynamicAssemblyBuilder.cs
@@ -12,24 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
 internal sealed class DynamicAssemblyBuilder : DynamicBuilder<DynamicAssemblyBuilder>
 {
-    public DynamicAssemblyBuilder(string name, AssemblyBuilder assemblyBuilder, string path) : base(name)
+    public DynamicAssemblyBuilder(string name, AssemblyBuilder assemblyBuilder) : base(name)
     {
-        TypeLibPath = path;
         AssemblyBuilder = assemblyBuilder;
         ModuleBuilder = CreateModuleBuilder();
         AppDomain.CurrentDomain.AssemblyResolve += ResolveEventHandler;
     }
 
     private List<DynamicTypeBuilder> DynamicTypeBuilder { get; } = new List<DynamicTypeBuilder>();
-
-    private string TypeLibPath { get; }
 
     public ModuleBuilder ModuleBuilder { get; set; }
 
@@ -49,7 +45,7 @@ internal sealed class DynamicAssemblyBuilder : DynamicBuilder<DynamicAssemblyBui
         return null;
     }
 
-    public DynamicAssemblyBuilderResult Build(bool storeOnDisk = true, bool skipTlbExeCall = false, bool useComAlias = false)
+    public DynamicAssemblyBuilderResult Build(bool useComAlias = false)
     {
         foreach (var customAttributeBuilder in CustomAttributeBuilder)
         {
@@ -58,37 +54,12 @@ internal sealed class DynamicAssemblyBuilder : DynamicBuilder<DynamicAssemblyBui
 
         DynamicTypeBuilder.ForEach(dynamicTypeBuilder => dynamicTypeBuilder.CreateType());
 
-        // Only supported for .NET Framework
-        if (!skipTlbExeCall)
-        {
-            CreateDLLAndCreateTLBWithTlbExe();
-        }
-
         var typeLibConverter = new TypeLibConverter();
         var assembly = ModuleBuilder.Assembly;
-        var tlbFilePath = storeOnDisk ? TypeLibPath : string.Empty;
         var typeLibExporterNotifySink = new TypeLibExporterNotifySink(useComAlias ? assembly : null);
-        if (typeLibConverter.ConvertAssemblyToTypeLib(assembly, tlbFilePath, typeLibExporterNotifySink) is not ITypeLib2 typelib)
+        if (typeLibConverter.ConvertAssemblyToTypeLib(assembly, string.Empty, typeLibExporterNotifySink) is not ITypeLib2 typelib)
         {
             throw new COMException("Cannot create type library for this dynamic assembly");
-        }
-
-        if (storeOnDisk && typelib is ICreateTypeLib2 createTypeLib2)
-        {
-            createTypeLib2.SaveAllChanges().ThrowIfFailed($"Failed to save type library {tlbFilePath}.");
-        }
-
-        if (storeOnDisk)
-        {
-            var options = new TypeLibTextConverterSettings()
-            {
-                Out = $"{TypeLibPath}.yaml",
-                TypeLibrary = TypeLibPath,
-                FilterRegex = new string[] { "file" }
-            };
-
-            var typeLibConvert = new TypeLibConverter();
-            typeLibConvert.ConvertTypeLibToText(options);
         }
 
         AppDomain.CurrentDomain.AssemblyResolve -= ResolveEventHandler;
@@ -140,56 +111,8 @@ internal sealed class DynamicAssemblyBuilder : DynamicBuilder<DynamicAssemblyBui
         DynamicTypeBuilder.Remove(toCreate);
     }
 
-    [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Compatibility")]
-    private void CreateDLLAndCreateTLBWithTlbExe()
-    {
-#if NETFRAMEWORK && DEBUG
-
-        var dllPath = $"{TypeLibPath}.dll";
-
-        AssemblyBuilder.Save(Path.GetFileName($"{TypeLibPath}.dll"));
-
-        var tlbexpexePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), @"Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\TlbExp.exe");
-
-        if (File.Exists(tlbexpexePath))
-        {
-            var process = new System.Diagnostics.Process();
-            process.StartInfo.FileName = tlbexpexePath;
-            process.StartInfo.UseShellExecute = false;
-            process.StartInfo.RedirectStandardOutput = false;
-            process.StartInfo.RedirectStandardError = false;
-            process.StartInfo.Arguments = $"{dllPath} /win64 /out:{dllPath}.tlbexp.tlb";
-            process.StartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Maximized;
-
-            process.Start();
-
-            process.WaitForExit();
-        }
-
-        var options = new TypeLibTextConverterSettings()
-        {
-            Out = $"{dllPath}.tlbexp.tlb.yaml",
-            TypeLibrary = $"{dllPath}.tlbexp.tlb"
-        };
-
-        if (File.Exists(options.TypeLibrary))
-        {
-            var typeLibConvert = new TypeLibConverter();
-            typeLibConvert.ConvertTypeLibToText(options);
-        }
-
-#endif
-    }
-
-#if NETFRAMEWORK
-    private ModuleBuilder CreateModuleBuilder()
-    {
-        return AssemblyBuilder.DefineDynamicModule("DynamicTestModule", $"{Path.GetFileName($"{TypeLibPath}.dll")}");
-    }
-#else
     private ModuleBuilder CreateModuleBuilder()
     {
         return AssemblyBuilder.DefineDynamicModule("DynamicTestModule"); ;
     }
-#endif
 }

--- a/src/dscom.test/tests/MarshalAsTest.cs
+++ b/src/dscom.test/tests/MarshalAsTest.cs
@@ -323,7 +323,7 @@ public class MarshalAsTest : BaseTest
             .Build();
         }
 
-        var result = interface2.Build().Build(true, true);
+        var result = interface2.Build().Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
         typeInfo.Should().NotBeNull("TestInterface should be generated");

--- a/src/dscom.test/tests/MemIdTest.cs
+++ b/src/dscom.test/tests/MemIdTest.cs
@@ -89,7 +89,7 @@ public class MemIdTest : BaseTest
                             .WithMethod("Method1").WithReturnType<string>().WithCustomAttribute<DispIdAttribute>(dispIdStart + 1).Build()
                             .WithMethod("Method2").WithReturnType<string>().Build()
                         .Build()
-                    .Build(true, true);
+                    .Build();
 
         using var method1 = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("Method1");
         using var method2 = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("Method2");


### PR DESCRIPTION
The writing of temporary dll and tlb files has been removed.  
In the case of parallel execution of the UnitTest, this is not stable and sporadically generates errors. 
In addition, a large number of files are generated that are neither used for test execution nor do they provide any advantage.
The test execution time can thus be massively accelerated.