### PR TITLE
test: FluentAssertions removed

### DIFF
--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -14,10 +14,12 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.2.0
         with:
           global-json-file: global.json
-
+        env:
+          # https://github.com/dotnet/sdk/issues/44957
+          DOTNET_INSTALL_DIR: ${{ runner.temp }}/.dotnet
       - name: Restore dependencies
         run: dotnet restore
 

--- a/src/dscom.test/Extensions.cs
+++ b/src/dscom.test/Extensions.cs
@@ -76,7 +76,7 @@ public static class Extensions
     public static DisposableStruct<VARDESC>? GetVarDescByName(this ITypeInfo2 typeInfo, string name)
     {
         using var attributes = typeInfo.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
+        Assert.NotNull(attributes);
 
         int numberOfVars = attributes!.Value.cVars;
         for (var i = 0; i < numberOfVars; i++)
@@ -113,8 +113,7 @@ public static class Extensions
     {
         typeInfo.GetTypeAttr(out var ppTypAttr);
 
-        using var attribute = typeInfo.GetTypeInfoAttributes();
-        attribute.Should().NotBeNull();
+        using var attribute = typeInfo.GetTypeInfoAttributes() ?? throw new InvalidOperationException("TypeInfo attributes should not be null.");
         int numberOfFunction = attribute!.Value.cFuncs;
         for (var i = 0; i < numberOfFunction; i++)
         {
@@ -154,8 +153,7 @@ public static class Extensions
     public static KeyValuePair<string, object>[] GetAllEnumValues(this ITypeInfo2 typeInfo)
     {
         var retVal = new List<KeyValuePair<string, object>>();
-        using var attribute = typeInfo.GetTypeInfoAttributes();
-        attribute.Should().NotBeNull();
+        using var attribute = typeInfo.GetTypeInfoAttributes() ?? throw new InvalidOperationException("TypeInfo attributes should not be null.");
         var count = attribute!.Value.cVars;
         for (short i = 0; i < count; i++)
         {

--- a/src/dscom.test/GlobalSuppressions.cs
+++ b/src/dscom.test/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE0005:Using directive is unnecessary.", Justification = "<Pending>")]

--- a/src/dscom.test/GlobalUsing.cs
+++ b/src/dscom.test/GlobalUsing.cs
@@ -20,7 +20,6 @@ global using System.Reflection;
 global using System.Reflection.Emit;
 global using System.Runtime.CompilerServices;
 global using System.Text.RegularExpressions;
-global using FluentAssertions;
 global using Xunit;
 
 #pragma warning disable CS8019

--- a/src/dscom.test/dscom.test.csproj
+++ b/src/dscom.test/dscom.test.csproj
@@ -14,7 +14,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="[7.0.0]" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="moq" Version="4.20.72" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />

--- a/src/dscom.test/tests/AttributeFlagTests.cs
+++ b/src/dscom.test/tests/AttributeFlagTests.cs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 using dSPACE.Runtime.InteropServices.Attributes;
-using FUNCFLAGS = System.Runtime.InteropServices.ComTypes.FUNCFLAGS;
 using Xunit;
+using FUNCFLAGS = System.Runtime.InteropServices.ComTypes.FUNCFLAGS;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 

--- a/src/dscom.test/tests/AttributeFlagTests.cs
+++ b/src/dscom.test/tests/AttributeFlagTests.cs
@@ -14,6 +14,7 @@
 
 using dSPACE.Runtime.InteropServices.Attributes;
 using FUNCFLAGS = System.Runtime.InteropServices.ComTypes.FUNCFLAGS;
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -39,11 +40,11 @@ public class AttributeFlagTests : BaseTest
 
         if (interfaceIsHidden)
         {
-            flags.Should().HaveFlag(TYPEFLAGS.TYPEFLAG_FHIDDEN);
+            Assert.True(flags.HasValue && flags.Value.HasFlag(TYPEFLAGS.TYPEFLAG_FHIDDEN));
         }
         else
         {
-            flags.Should().NotHaveFlag(TYPEFLAGS.TYPEFLAG_FHIDDEN);
+            Assert.False(flags.HasValue && flags.Value.HasFlag(TYPEFLAGS.TYPEFLAG_FHIDDEN));
         }
     }
 
@@ -68,11 +69,11 @@ public class AttributeFlagTests : BaseTest
 
         if (memberIsHidden)
         {
-            flags.Should().HaveFlag(FUNCFLAGS.FUNCFLAG_FHIDDEN);
+            Assert.True(flags.HasFlag(FUNCFLAGS.FUNCFLAG_FHIDDEN));
         }
         else
         {
-            flags.Should().NotHaveFlag(FUNCFLAGS.FUNCFLAG_FHIDDEN);
+            Assert.False(flags.HasFlag(FUNCFLAGS.FUNCFLAG_FHIDDEN));
         }
     }
 
@@ -96,11 +97,11 @@ public class AttributeFlagTests : BaseTest
 
         if (interfaceIsRestricted)
         {
-            flags.Should().HaveFlag(TYPEFLAGS.TYPEFLAG_FRESTRICTED);
+            Assert.True(flags.HasValue && flags.Value.HasFlag(TYPEFLAGS.TYPEFLAG_FRESTRICTED));
         }
         else
         {
-            flags.Should().NotHaveFlag(TYPEFLAGS.TYPEFLAG_FRESTRICTED);
+            Assert.False(flags.HasValue && flags.Value.HasFlag(TYPEFLAGS.TYPEFLAG_FRESTRICTED));
         }
     }
 
@@ -125,11 +126,11 @@ public class AttributeFlagTests : BaseTest
 
         if (memberIsRestricted)
         {
-            flags.Should().HaveFlag(FUNCFLAGS.FUNCFLAG_FRESTRICTED);
+            Assert.True(flags.HasFlag(FUNCFLAGS.FUNCFLAG_FRESTRICTED));
         }
         else
         {
-            flags.Should().NotHaveFlag(FUNCFLAGS.FUNCFLAG_FRESTRICTED);
+            Assert.False(flags.HasFlag(FUNCFLAGS.FUNCFLAG_FRESTRICTED));
         }
     }
 }

--- a/src/dscom.test/tests/CLITest/CLITest.cs
+++ b/src/dscom.test/tests/CLITest/CLITest.cs
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace dSPACE.Runtime.InteropServices.Tests;
-
 using Xunit;
 
+namespace dSPACE.Runtime.InteropServices.Tests;
 /// <summary>
 /// The basic CLI tests to run.
 /// </summary>
@@ -163,9 +162,8 @@ public class CLITest : CLITestBase
         var parameters = new[] { "tlbexport", TestAssemblyPath, "--createmissingdependenttlbs", "false", "--overridetlbid", "12345678-1234-1234-1234-123456789012" };
 
         var result = Execute(DSComPath, parameters);
-        Assert.Equal(0, result.ExitCode);
-        var fileName = Path.GetFileNameWithoutExtension(TestAssemblyPath);
 
+        Assert.Equal(0, result.ExitCode);
         Assert.True(File.Exists(tlbFilePath));
     }
 
@@ -183,9 +181,6 @@ public class CLITest : CLITestBase
 
     public void TlbExportCreateMissingDependentTLBsTrue_ExitCodeIs0AndTlbIsAvailableAndDependentTlbIsNot()
     {
-        var dependentFileName = Path.GetFileName(TestAssemblyDependencyTemporyTlbFilePath);
-        var dependentTlbPath = Path.Combine(Path.GetDirectoryName(TestAssemblyTemporyTlbFilePath)!, dependentFileName);
-
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, "--createmissingdependenttlbs", "false", "--out", TestAssemblyTemporyTlbFilePath);
         Assert.Equal(0, result.ExitCode);
 

--- a/src/dscom.test/tests/CLITest/CLITest.cs
+++ b/src/dscom.test/tests/CLITest/CLITest.cs
@@ -14,6 +14,8 @@
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
+using Xunit;
+
 /// <summary>
 /// The basic CLI tests to run.
 /// </summary>
@@ -26,92 +28,92 @@ public class CLITest : CLITestBase
     {
         var result = Execute(DSComPath);
 
-        result.ExitCode.Should().Be(1);
-        result.StdErr.Trim().Should().Be(ErrorNoCommandOrOptions);
-        result.StdOut.Trim().Should().Contain("Description");
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("Usage:", result.StdOut);
+        Assert.Contains(ErrorNoCommandOrOptions, result.StdErr);
     }
 
     public void CallWithoutCommandABC_ExitCodeIs1AndStdOutIsHelpStringAndStdErrIsUsed()
     {
         var result = Execute(DSComPath, "ABC");
 
-        result.ExitCode.Should().Be(1);
-        result.StdErr.Trim().Should().Contain(ErrorNoCommandOrOptions);
-        result.StdErr.Trim().Should().Contain("Unrecognized command or argument 'ABC'");
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("Usage:", result.StdOut);
+        Assert.Contains("Unrecognized command or argument 'abc'", result.StdErr);
     }
 
     public void CallWithVersionOption_VersionIsAssemblyInformationalVersionAttributeValue()
     {
         var assemblyInformationalVersion = typeof(TypeLibConverter).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-        assemblyInformationalVersion.Should().NotBeNull("AssemblyInformationalVersionAttribute is not set");
+        Assert.NotNull(assemblyInformationalVersion);
         var versionFromLib = assemblyInformationalVersion!.InformationalVersion;
 
         var result = Execute(DSComPath, "--version");
-        result.ExitCode.Should().Be(0);
-        versionFromLib.Should().StartWith(result.StdOut.Trim());
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains(versionFromLib, result.StdOut);
     }
 
     public void CallWithHelpOption_StdOutIsHelpStringAndExitCodeIsZero()
     {
         var result = Execute(DSComPath, "--help");
-        result.ExitCode.Should().Be(0);
-        result.StdOut.Trim().Should().Contain("Description");
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Usage:", result.StdOut);
     }
 
     public void TlbExportAndHelpOption_StdOutIsHelpStringAndExitCodeIsZero()
     {
         var result = Execute(DSComPath, "tlbexport", "--help");
-        result.ExitCode.Should().Be(0);
-        result.StdOut.Trim().Should().Contain("Description");
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Usage:", result.StdOut);
     }
 
     public void TlbDumpAndHelpOption_StdOutIsHelpStringAndExitCodeIsZero()
     {
         var result = Execute(DSComPath, "tlbdump", "--help");
-        result.ExitCode.Should().Be(0);
-        result.StdOut.Trim().Should().Contain("Description");
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Usage:", result.StdOut);
     }
 
     public void TlbRegisterAndHelpOption_StdOutIsHelpStringAndExitCodeIsZero()
     {
         var result = Execute(DSComPath, "tlbregister", "--help");
-        result.ExitCode.Should().Be(0);
-        result.StdOut.Trim().Should().Contain("Description");
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Usage:", result.StdOut);
     }
 
     public void TlbUnRegisterAndHelpOption_StdOutIsHelpStringAndExitCodeIsZero()
     {
         var result = Execute(DSComPath, "tlbunregister", "--help");
-        result.ExitCode.Should().Be(0);
-        result.StdOut.Trim().Should().Contain("Description");
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Usage:", result.StdOut);
     }
 
     public void TlbUnRegisterAndFileNotExist_StdErrIsFileNotFoundAndExitCodeIs1()
     {
         var result = Execute(DSComPath, "tlbunregister", "abc");
-        result.ExitCode.Should().Be(1);
-        result.StdErr.Trim().Should().Contain("not found");
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("File not found", result.StdErr);
     }
 
     public void TlbRegisterAndFileNotExist_StdErrIsFileNotFoundAndExitCodeIs1()
     {
         var result = Execute(DSComPath, "tlbregister", "abc");
-        result.ExitCode.Should().Be(1);
-        result.StdErr.Trim().Should().Contain("not found");
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("File not found", result.StdErr);
     }
 
     public void TlbDumpAndFileNotExist_StdErrIsFileNotFoundAndExitCodeIs1()
     {
         var result = Execute(DSComPath, "tlbdump", "abc");
-        result.ExitCode.Should().Be(1);
-        result.StdErr.Trim().Should().Contain("not found");
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("File not found", result.StdErr);
     }
 
     public void TlbExportAndFileNotExist_StdErrIsFileNotFoundAndExitCodeIs1()
     {
         var result = Execute(DSComPath, "tlbexport", "abc");
-        result.ExitCode.Should().Be(1);
-        result.StdErr.Trim().Should().Contain("not found");
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("File not found", result.StdErr);
     }
 
     public void TlbExportAndDemoAssemblyAndCallWithTlbDump_ExitCodeIs0AndTlbIsAvailableAndValid()
@@ -120,15 +122,15 @@ public class CLITest : CLITestBase
         var dependentTlbPath = Path.Combine(Path.GetDirectoryName(TestAssemblyTemporyTlbFilePath)!, dependentFileName);
 
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, "--out", TestAssemblyTemporyTlbFilePath);
-        result.ExitCode.Should().Be(0);
+        Assert.Equal(0, result.ExitCode);
 
-        File.Exists(TestAssemblyTemporyTlbFilePath).Should().BeTrue($"File {TestAssemblyTemporyTlbFilePath} should be available.");
-        File.Exists(dependentTlbPath).Should().BeTrue($"File {dependentTlbPath} should be available.");
+        Assert.True(File.Exists(TestAssemblyTemporyTlbFilePath));
+        Assert.True(File.Exists(dependentTlbPath));
 
         var dumpResult = Execute(DSComPath, "tlbdump", TestAssemblyTemporyTlbFilePath, "--out", TestAssemblyTemporyYamlFilePath);
-        dumpResult.ExitCode.Should().Be(0);
+        Assert.Equal(0, dumpResult.ExitCode);
 
-        File.Exists(TestAssemblyTemporyYamlFilePath).Should().BeTrue($"File {TestAssemblyTemporyYamlFilePath} should be available.");
+        Assert.True(File.Exists(TestAssemblyTemporyYamlFilePath));
     }
 
     public void TlbExportAndEmbedAssembly_ExitCodeIs0AndTlbIsEmbeddedAndValid()
@@ -139,10 +141,10 @@ public class CLITest : CLITestBase
         var dependentTlbPath = Path.Combine(Path.GetDirectoryName(TestAssemblyTemporyTlbFilePath)!, dependentFileName);
 
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, $"--embed {embedPath}", "--out", TestAssemblyTemporyTlbFilePath);
-        result.ExitCode.Should().Be(0, $"because it should succeed. Error: ${result.StdErr}. Output: ${result.StdOut}");
+        Assert.Equal(0, result.ExitCode);
 
-        File.Exists(TestAssemblyTemporyTlbFilePath).Should().BeTrue($"File {TestAssemblyTemporyTlbFilePath} should be available.");
-        File.Exists(dependentTlbPath).Should().BeTrue($"File {dependentTlbPath} should be available.");
+        Assert.True(File.Exists(TestAssemblyTemporyTlbFilePath));
+        Assert.True(File.Exists(dependentTlbPath));
 
         OleAut32.LoadTypeLibEx(embedPath, REGKIND.NONE, out var embeddedTypeLib);
         OleAut32.LoadTypeLibEx(TestAssemblyTemporyTlbFilePath, REGKIND.NONE, out var sourceTypeLib);
@@ -161,25 +163,22 @@ public class CLITest : CLITestBase
         var parameters = new[] { "tlbexport", TestAssemblyPath, "--createmissingdependenttlbs", "false", "--overridetlbid", "12345678-1234-1234-1234-123456789012" };
 
         var result = Execute(DSComPath, parameters);
-        result.ExitCode.Should().Be(0);
+        Assert.Equal(0, result.ExitCode);
         var fileName = Path.GetFileNameWithoutExtension(TestAssemblyPath);
 
-        result.StdOut.Should().NotContain($"{fileName} does not have a type library");
-        result.StdErr.Should().NotContain($"{fileName} does not have a type library");
-
-        File.Exists(tlbFilePath).Should().BeTrue($"File {tlbFilePath} should be available.");
+        Assert.True(File.Exists(tlbFilePath));
     }
 
     public void TlbExportCreateMissingDependentTLBsFalse_ExitCodeIs0AndTlbIsAvailableAndDependentTlbIsNot()
     {
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, "--createmissingdependenttlbs", "false", "--out", TestAssemblyTemporyTlbFilePath);
-        result.ExitCode.Should().Be(0);
+        Assert.Equal(0, result.ExitCode);
 
-        File.Exists(TestAssemblyTemporyTlbFilePath).Should().BeTrue($"File {TestAssemblyTemporyTlbFilePath} should be available.");
-        File.Exists(TestAssemblyDependencyTemporyTlbFilePath).Should().BeFalse($"File {TestAssemblyDependencyTemporyTlbFilePath} should not be available.");
+        Assert.True(File.Exists(TestAssemblyTemporyTlbFilePath));
+        Assert.False(File.Exists(TestAssemblyDependencyTemporyTlbFilePath));
 
-        result.StdErr.Should().Contain("auto generation of dependent type libs is disabled");
-        result.StdErr.Should().Contain(Path.GetFileNameWithoutExtension(TestAssemblyDependencyPath));
+        Assert.Contains("auto generation of dependent type libs is disabled", result.StdErr);
+        Assert.Contains(Path.GetFileNameWithoutExtension(TestAssemblyDependencyPath), result.StdErr);
     }
 
     public void TlbExportCreateMissingDependentTLBsTrue_ExitCodeIs0AndTlbIsAvailableAndDependentTlbIsNot()
@@ -188,10 +187,10 @@ public class CLITest : CLITestBase
         var dependentTlbPath = Path.Combine(Path.GetDirectoryName(TestAssemblyTemporyTlbFilePath)!, dependentFileName);
 
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, "--createmissingdependenttlbs", "false", "--out", TestAssemblyTemporyTlbFilePath);
-        result.ExitCode.Should().Be(0);
+        Assert.Equal(0, result.ExitCode);
 
-        File.Exists(TestAssemblyTemporyTlbFilePath).Should().BeTrue($"File {TestAssemblyTemporyTlbFilePath} should be available.");
-        File.Exists(TestAssemblyDependencyTemporyTlbFilePath).Should().BeFalse($"File {dependentTlbPath} should be available.");
+        Assert.True(File.Exists(TestAssemblyTemporyTlbFilePath));
+        Assert.False(File.Exists(TestAssemblyDependencyTemporyTlbFilePath));
     }
 
     public void TlbExportCreateMissingDependentTLBsNoValue_ExitCodeIs0()
@@ -200,32 +199,32 @@ public class CLITest : CLITestBase
         var dependentTlbPath = Path.Combine(Path.GetDirectoryName(TestAssemblyTemporyTlbFilePath)!, dependentFileName);
 
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, "--createmissingdependenttlbs", "--out", TestAssemblyTemporyTlbFilePath);
-        result.ExitCode.Should().Be(0);
+        Assert.Equal(0, result.ExitCode);
 
-        File.Exists(TestAssemblyTemporyTlbFilePath).Should().BeTrue($"File {TestAssemblyTemporyTlbFilePath} should be available.");
-        File.Exists(dependentTlbPath).Should().BeTrue($"File {dependentTlbPath} should be available.");
+        Assert.True(File.Exists(TestAssemblyTemporyTlbFilePath));
+        Assert.True(File.Exists(dependentTlbPath));
     }
 
     public void TlbExportAndOptionSilent_StdOutAndStdErrIsEmpty()
     {
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, "--silent", "--out", TestAssemblyTemporyTlbFilePath);
-        result.ExitCode.Should().Be(0);
+        Assert.Equal(0, result.ExitCode);
 
-        File.Exists(TestAssemblyTemporyTlbFilePath).Should().BeTrue($"File {TestAssemblyTemporyTlbFilePath} should be available.");
+        Assert.True(File.Exists(TestAssemblyTemporyTlbFilePath));
 
-        result.StdOut.Trim().Should().BeNullOrEmpty();
-        result.StdErr.Trim().Should().BeNullOrEmpty();
+        Assert.True(string.IsNullOrEmpty(result.StdOut.Trim()));
+        Assert.True(string.IsNullOrEmpty(result.StdErr.Trim()));
     }
 
     public void TlbExportAndOptionSilenceTX801311A6andTX0013116F_StdOutAndStdErrIsEmpty()
     {
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, "--silence", "TX801311A6", "--silence", "TX0013116F", "--out", TestAssemblyTemporyTlbFilePath);
-        result.ExitCode.Should().Be(0);
+        Assert.Equal(0, result.ExitCode);
 
-        File.Exists(TestAssemblyTemporyTlbFilePath).Should().BeTrue($"File {TestAssemblyTemporyTlbFilePath} should be available.");
+        Assert.True(File.Exists(TestAssemblyTemporyTlbFilePath));
 
-        result.StdOut.Trim().Should().BeNullOrEmpty();
-        result.StdErr.Trim().Should().BeNullOrEmpty();
+        Assert.True(string.IsNullOrEmpty(result.StdOut.Trim()));
+        Assert.True(string.IsNullOrEmpty(result.StdErr.Trim()));
     }
 
     public void TlbExportAndOptionOverrideTLBId_TLBIdIsCorrect()
@@ -234,15 +233,15 @@ public class CLITest : CLITestBase
 
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, "--out", TestAssemblyTemporyTlbFilePath, "--overridetlbid", guid.ToString());
 
-        result.ExitCode.Should().Be(0);
-        File.Exists(TestAssemblyTemporyTlbFilePath).Should().BeTrue($"File {TestAssemblyTemporyTlbFilePath} should be available.");
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(File.Exists(TestAssemblyTemporyTlbFilePath));
 
         var dumpResult = Execute(DSComPath, "tlbdump", TestAssemblyTemporyTlbFilePath, "/out", TestAssemblyTemporyYamlFilePath);
-        dumpResult.ExitCode.Should().Be(0);
+        Assert.Equal(0, dumpResult.ExitCode);
 
-        File.Exists(TestAssemblyTemporyYamlFilePath).Should().BeTrue($"File {TestAssemblyTemporyYamlFilePath} should be available.");
+        Assert.True(File.Exists(TestAssemblyTemporyYamlFilePath));
 
         var yamlContent = File.ReadAllText(TestAssemblyTemporyYamlFilePath);
-        yamlContent.Should().Contain($"guid: {guid}");
+        Assert.Contains($"guid: {guid}", yamlContent);
     }
 }

--- a/src/dscom.test/tests/CLITest/CLITest.cs
+++ b/src/dscom.test/tests/CLITest/CLITest.cs
@@ -122,13 +122,11 @@ public class CLITest : CLITestBase
 
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, "--out", TestAssemblyTemporyTlbFilePath);
         Assert.Equal(0, result.ExitCode);
-
         Assert.True(File.Exists(TestAssemblyTemporyTlbFilePath));
         Assert.True(File.Exists(dependentTlbPath));
 
         var dumpResult = Execute(DSComPath, "tlbdump", TestAssemblyTemporyTlbFilePath, "--out", TestAssemblyTemporyYamlFilePath);
         Assert.Equal(0, dumpResult.ExitCode);
-
         Assert.True(File.Exists(TestAssemblyTemporyYamlFilePath));
     }
 
@@ -158,7 +156,6 @@ public class CLITest : CLITestBase
     {
         var tlbFileName = $"{Path.GetFileNameWithoutExtension(TestAssemblyPath)}.tlb";
         var tlbFilePath = Path.Combine(Environment.CurrentDirectory, tlbFileName);
-
         var parameters = new[] { "tlbexport", TestAssemblyPath, "--createmissingdependenttlbs", "false", "--overridetlbid", "12345678-1234-1234-1234-123456789012" };
 
         var result = Execute(DSComPath, parameters);
@@ -170,11 +167,10 @@ public class CLITest : CLITestBase
     public void TlbExportCreateMissingDependentTLBsFalse_ExitCodeIs0AndTlbIsAvailableAndDependentTlbIsNot()
     {
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, "--createmissingdependenttlbs", "false", "--out", TestAssemblyTemporyTlbFilePath);
-        Assert.Equal(0, result.ExitCode);
 
+        Assert.Equal(0, result.ExitCode);
         Assert.True(File.Exists(TestAssemblyTemporyTlbFilePath));
         Assert.False(File.Exists(TestAssemblyDependencyTemporyTlbFilePath));
-
         Assert.Contains("auto generation of dependent type libs is disabled", result.StdErr);
         Assert.Contains(Path.GetFileNameWithoutExtension(TestAssemblyDependencyPath), result.StdErr);
     }
@@ -182,8 +178,8 @@ public class CLITest : CLITestBase
     public void TlbExportCreateMissingDependentTLBsTrue_ExitCodeIs0AndTlbIsAvailableAndDependentTlbIsNot()
     {
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, "--createmissingdependenttlbs", "false", "--out", TestAssemblyTemporyTlbFilePath);
-        Assert.Equal(0, result.ExitCode);
 
+        Assert.Equal(0, result.ExitCode);
         Assert.True(File.Exists(TestAssemblyTemporyTlbFilePath));
         Assert.False(File.Exists(TestAssemblyDependencyTemporyTlbFilePath));
     }
@@ -194,8 +190,8 @@ public class CLITest : CLITestBase
         var dependentTlbPath = Path.Combine(Path.GetDirectoryName(TestAssemblyTemporyTlbFilePath)!, dependentFileName);
 
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, "--createmissingdependenttlbs", "--out", TestAssemblyTemporyTlbFilePath);
-        Assert.Equal(0, result.ExitCode);
 
+        Assert.Equal(0, result.ExitCode);
         Assert.True(File.Exists(TestAssemblyTemporyTlbFilePath));
         Assert.True(File.Exists(dependentTlbPath));
     }
@@ -203,10 +199,9 @@ public class CLITest : CLITestBase
     public void TlbExportAndOptionSilent_StdOutAndStdErrIsEmpty()
     {
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, "--silent", "--out", TestAssemblyTemporyTlbFilePath);
+
         Assert.Equal(0, result.ExitCode);
-
         Assert.True(File.Exists(TestAssemblyTemporyTlbFilePath));
-
         Assert.True(string.IsNullOrEmpty(result.StdOut.Trim()));
         Assert.True(string.IsNullOrEmpty(result.StdErr.Trim()));
     }
@@ -214,10 +209,9 @@ public class CLITest : CLITestBase
     public void TlbExportAndOptionSilenceTX801311A6andTX0013116F_StdOutAndStdErrIsEmpty()
     {
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, "--silence", "TX801311A6", "--silence", "TX0013116F", "--out", TestAssemblyTemporyTlbFilePath);
+
         Assert.Equal(0, result.ExitCode);
-
         Assert.True(File.Exists(TestAssemblyTemporyTlbFilePath));
-
         Assert.True(string.IsNullOrEmpty(result.StdOut.Trim()));
         Assert.True(string.IsNullOrEmpty(result.StdErr.Trim()));
     }
@@ -233,7 +227,6 @@ public class CLITest : CLITestBase
 
         var dumpResult = Execute(DSComPath, "tlbdump", TestAssemblyTemporyTlbFilePath, "/out", TestAssemblyTemporyYamlFilePath);
         Assert.Equal(0, dumpResult.ExitCode);
-
         Assert.True(File.Exists(TestAssemblyTemporyYamlFilePath));
 
         var yamlContent = File.ReadAllText(TestAssemblyTemporyYamlFilePath);

--- a/src/dscom.test/tests/CLITest/CLITestBase.cs
+++ b/src/dscom.test/tests/CLITest/CLITestBase.cs
@@ -14,6 +14,7 @@
 
 using System.Diagnostics;
 using System.Text;
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -106,7 +107,7 @@ public abstract class CLITestBase : IClassFixture<CompileReleaseFixture>, IDispo
     internal static string GetEmbeddedPath(string sourceAssemblyFile)
     {
         var embedFile = Path.Combine(Path.GetDirectoryName(sourceAssemblyFile) ?? string.Empty, Path.GetFileNameWithoutExtension(sourceAssemblyFile) + ".comhost" + Path.GetExtension(sourceAssemblyFile));
-        File.Exists(embedFile).Should().BeTrue($"File {embedFile} must exist prior to running the test.");
+        Assert.True(File.Exists(embedFile));
         return embedFile;
     }
 

--- a/src/dscom.test/tests/CLITest/CLITestEmbed.cs
+++ b/src/dscom.test/tests/CLITest/CLITestEmbed.cs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace dSPACE.Runtime.InteropServices.Tests;
+using Xunit;
 
+namespace dSPACE.Runtime.InteropServices.Tests;
 /// <summary>
 /// The tests for embeds are performed as a separate class due to the additional setup
 /// required and the need for creating a TLB file as part of export prior to testing
@@ -36,27 +37,28 @@ public class CLITestEmbed : CLITestBase
         TlbFilePath = Path.Combine(outputDirectory.FullName, tlbFileName);
 
         var result = Execute(DSComPath, "tlbexport", TestAssemblyPath, "--out", TlbFilePath);
-        result.ExitCode.Should().Be(0, $"because it should succeed. Error: ${result.StdErr}. Output: ${result.StdOut}");
+        Assert.Equal(0, result.ExitCode);
 
         result = Execute(DSComPath, "tlbexport", TestAssemblyDependencyPath);
-        result.ExitCode.Should().Be(0, $"because it should succeed. Error: ${result.StdErr}. Output: ${result.StdOut}");
+        Assert.Equal(0, result.ExitCode);
 
         DependentTlbPath = $"{Path.GetFileNameWithoutExtension(TestAssemblyDependencyPath)}.tlb";
 
-        File.Exists(TlbFilePath).Should().BeTrue($"File {TlbFilePath} should be available.");
-        File.Exists(DependentTlbPath).Should().BeTrue($"File {DependentTlbPath} should be available.");
+        Assert.True(File.Exists(TlbFilePath));
+        Assert.True(File.Exists(DependentTlbPath));
 
         // This is necessary to ensure the process from previous Execute for the export command has completely disposed before running tests.
         GC.Collect();
         GC.WaitForPendingFinalizers();
     }
 
+    [Fact]
     public void TlbEmbedAssembly_ExitCodeIs0AndTlbIsEmbeddedAndValid()
     {
         var embedPath = GetEmbeddedPath(TestAssemblyPath);
 
         var result = Execute(DSComPath, "tlbembed", TlbFilePath, embedPath);
-        result.ExitCode.Should().Be(0, $"because embedding should succeed. Output: {result.StdErr} ");
+        Assert.Equal(0, result.ExitCode);
 
         OleAut32.LoadTypeLibEx(embedPath, REGKIND.NONE, out var embeddedTypeLib);
         OleAut32.LoadTypeLibEx(TlbFilePath, REGKIND.NONE, out var sourceTypeLib);
@@ -67,11 +69,12 @@ public class CLITestEmbed : CLITestBase
         Assert.Equal(sourceTypeLibName, embeddedTypeLibName);
     }
 
+    [Fact]
     public void TlbEmbedAssemblyWithArbitraryIndex_ExitCodeIs0AndTlbIsEmbeddedAndValid()
     {
         var embedPath = GetEmbeddedPath(TestAssemblyPath);
         var result = Execute(DSComPath, "tlbembed", TlbFilePath, embedPath, "--index 2");
-        result.ExitCode.Should().Be(0);
+        Assert.Equal(0, result.ExitCode);
 
         OleAut32.LoadTypeLibEx(embedPath + "\\2", REGKIND.NONE, out var embeddedTypeLib);
         OleAut32.LoadTypeLibEx(TlbFilePath, REGKIND.NONE, out var sourceTypeLib);
@@ -82,11 +85,12 @@ public class CLITestEmbed : CLITestBase
         Assert.Equal(sourceTypeLibName, embeddedTypeLibName);
     }
 
+    [Fact]
     public void TlbEmbedAssemblyWithArbitraryTlbAndArbitraryIndex_ExitCodeIs0AndTlbIsEmbeddedAndValid()
     {
         var embedPath = GetEmbeddedPath(TestAssemblyPath);
         var result = Execute(DSComPath, "tlbembed", TlbFilePath, embedPath, "--index 3");
-        result.ExitCode.Should().Be(0);
+        Assert.Equal(0, result.ExitCode);
 
         OleAut32.LoadTypeLibEx(embedPath + "\\3", REGKIND.NONE, out var embeddedTypeLib);
         OleAut32.LoadTypeLibEx(TlbFilePath, REGKIND.NONE, out var sourceTypeLib);
@@ -97,14 +101,15 @@ public class CLITestEmbed : CLITestBase
         Assert.Equal(sourceTypeLibName, embeddedTypeLibName);
     }
 
+    [Fact]
     public void TlbEmbedAssemblyWithMultipleTypeLibraries_ExitCodeAre0AndTlbsAreEmbeddedAndValid()
     {
         var embedPath = GetEmbeddedPath(TestAssemblyPath);
         var result = Execute(DSComPath, "tlbembed", TlbFilePath, embedPath);
-        result.ExitCode.Should().Be(0);
+        Assert.Equal(0, result.ExitCode);
 
         result = Execute(DSComPath, "tlbembed", DependentTlbPath, TestAssemblyPath, "--index 2");
-        result.ExitCode.Should().Be(0);
+        Assert.Equal(0, result.ExitCode);
 
         OleAut32.LoadTypeLibEx(embedPath, REGKIND.NONE, out var embeddedTypeLib1);
         OleAut32.LoadTypeLibEx(TlbFilePath, REGKIND.NONE, out var sourceTypeLib1);

--- a/src/dscom.test/tests/ClassTest.cs
+++ b/src/dscom.test/tests/ClassTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Runtime.InteropServices;
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -33,11 +34,11 @@ public class ClassTest : BaseTest
                         .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestClass");
-        typeInfo.Should().NotBeNull("TestClass not found");
+        Assert.NotNull(typeInfo);
 
         using var attributes = typeInfo!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.typekind.Should().Be(TYPEKIND.TKIND_COCLASS);
+        Assert.NotNull(attributes);
+        Assert.Equal(TYPEKIND.TKIND_COCLASS, attributes!.Value.typekind);
     }
 
     [Fact]
@@ -52,11 +53,11 @@ public class ClassTest : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestClass");
-        typeInfo.Should().NotBeNull("TestClass not found");
+        Assert.NotNull(typeInfo);
 
         using var attributes = typeInfo!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.typekind.Should().Be(TYPEKIND.TKIND_COCLASS);
+        Assert.NotNull(attributes);
+        Assert.Equal(TYPEKIND.TKIND_COCLASS, attributes!.Value.typekind);
 
         var index = 0;
         while (index < 2)
@@ -64,7 +65,7 @@ public class ClassTest : BaseTest
             typeInfo!.GetRefTypeOfImplType(index, out var href);
             typeInfo!.GetRefTypeInfo(href, out var ppTI);
             ppTI.GetDocumentation(-1, out var refTypeName, out var refTypeDocString, out var refTypeHelpContext, out var refTypeHelpFile);
-            refTypeName.Should().BeOneOf(InterfaceTest, "_TestClass");
+            Assert.Contains(refTypeName, new[] { InterfaceTest, "_TestClass" });
             index++;
         }
     }
@@ -78,11 +79,11 @@ public class ClassTest : BaseTest
                         .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestClass");
-        typeInfo.Should().NotBeNull("TestClass not found");
+        Assert.NotNull(typeInfo);
 
         using var attributes = typeInfo!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.typekind.Should().Be(TYPEKIND.TKIND_COCLASS);
+        Assert.NotNull(attributes);
+        Assert.Equal(TYPEKIND.TKIND_COCLASS, attributes!.Value.typekind);
     }
 
     [Fact]
@@ -94,11 +95,11 @@ public class ClassTest : BaseTest
                         .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("_TestClass");
-        typeInfo.Should().NotBeNull("_TestClass not found");
+        Assert.NotNull(typeInfo);
 
         using var attributes = typeInfo!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.typekind.Should().Be(TYPEKIND.TKIND_DISPATCH);
+        Assert.NotNull(attributes);
+        Assert.Equal(TYPEKIND.TKIND_DISPATCH, attributes!.Value.typekind);
     }
 
     [Fact]
@@ -111,7 +112,7 @@ public class ClassTest : BaseTest
                         .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("_TestClass");
-        typeInfo.Should().BeNull("_TestClass found");
+        Assert.Null(typeInfo);
     }
 
     [Fact]
@@ -124,11 +125,11 @@ public class ClassTest : BaseTest
                         .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("_TestClass");
-        typeInfo.Should().NotBeNull("_TestClass not found");
+        Assert.NotNull(typeInfo);
 
         using var attributes = typeInfo!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.typekind.Should().Be(TYPEKIND.TKIND_DISPATCH);
+        Assert.NotNull(attributes);
+        Assert.Equal(TYPEKIND.TKIND_DISPATCH, attributes!.Value.typekind);
     }
 
     [Fact]
@@ -152,13 +153,13 @@ public class ClassTest : BaseTest
                 .Build();
 
         var classInterface = result.TypeLib.GetTypeInfoByName("_TestClass");
-        classInterface.Should().NotBeNull();
+        Assert.NotNull(classInterface);
 
         using var attribute = classInterface!.GetTypeInfoAttributes();
-        attribute.Should().NotBeNull();
+        Assert.NotNull(attribute);
 
-        attribute!.Value.wMajorVerNum.Should().Be(0);
-        attribute!.Value.wMinorVerNum.Should().Be(0);
+        Assert.Equal(0, attribute!.Value.wMajorVerNum);
+        Assert.Equal(0, attribute!.Value.wMinorVerNum);
     }
 
     [Fact]
@@ -170,7 +171,7 @@ public class ClassTest : BaseTest
                     .Build()
                 .Build();
 
-        result.TypeLib.GetTypeInfoCount().Should().Be(0, "Generic CoClass should be ignored");
+        Assert.Equal(0, result.TypeLib.GetTypeInfoCount());
     }
 
     [Fact]
@@ -186,7 +187,7 @@ public class ClassTest : BaseTest
                 .Build()
             .Build();
 
-        result.TypeLib.GetTypeInfoCount().Should().Be(1, "Generic CoClass should be ignored, Derived class should be created.");
+        Assert.Equal(1, result.TypeLib.GetTypeInfoCount());
     }
 
     [Fact]
@@ -199,7 +200,7 @@ public class ClassTest : BaseTest
                     .Build()
                 .Build();
 
-        result.TypeLib.GetTypeInfoCount().Should().Be(0);
+        Assert.Equal(0, result.TypeLib.GetTypeInfoCount());
     }
 
     [Fact]
@@ -216,7 +217,7 @@ public class ClassTest : BaseTest
                 .Build()
             .Build();
 
-        result.TypeLib.GetTypeInfoCount().Should().Be(1, "Derived class should be created.");
+        Assert.Equal(1, result.TypeLib.GetTypeInfoCount());
     }
 
     [Fact]
@@ -236,23 +237,23 @@ public class ClassTest : BaseTest
             .Build();
 
         var type = result.TypeLib.GetTypeInfoByName("TestInterface");
-        type.Should().NotBeNull();
+        Assert.NotNull(type);
 
         var funcDesc = type!.GetFuncDescByName("TestMethod");
-        funcDesc!.Should().NotBeNull();
+        Assert.NotNull(funcDesc);
 
         var firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDesc!.Value.lprgelemdescParam);
-        firstParam.tdesc.GetVarEnum().Should().Be(VarEnum.VT_PTR, $"First parameter of TestMethod should be VT_PTR");
+        Assert.Equal(VarEnum.VT_PTR, firstParam.tdesc.GetVarEnum());
 
         var subtypeDesc = Marshal.PtrToStructure<TYPEDESC>(firstParam.tdesc.lpValue);
-        subtypeDesc.GetVarEnum().Should().Be(VarEnum.VT_USERDEFINED, $"Inner type of first parameter of TestMethod should be availble VarEnum.VT_USERDEFINED");
+        Assert.Equal(VarEnum.VT_USERDEFINED, subtypeDesc.GetVarEnum());
 
         var hrefType = subtypeDesc.lpValue;
 
         var typeInfo64Bit = (ITypeInfo64Bit)type!;
         typeInfo64Bit.GetRefTypeInfo(hrefType, out var refTypeInfo64Bit);
         refTypeInfo64Bit.GetDocumentation(-1, out var name, out _, out _, out _);
-        name.Should().Be(CustomInterface);
+        Assert.Equal(CustomInterface, name);
     }
 
     [Fact]
@@ -272,7 +273,7 @@ public class ClassTest : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("CustomClass");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         using var typeAttr = typeInfo!.GetTypeInfoAttributes();
 
@@ -286,11 +287,11 @@ public class ClassTest : BaseTest
 
             if (name == "CustomInterface1")
             {
-                pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT, "First interface should be the default interface");
+                Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT));
             }
             else
             {
-                pImplTypeFlags.Should().NotHaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT, "Only first interface should be the default interface");
+                Assert.False(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT));
             }
         }
     }
@@ -306,7 +307,7 @@ public class ClassTest : BaseTest
                 .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         using var typeAttr = typeInfo!.GetTypeInfoAttributes();
 
@@ -322,12 +323,12 @@ public class ClassTest : BaseTest
             if (name == SourceInterfaces)
             {
                 found = true;
-                pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT);
-                pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE);
+                Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT));
+                Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE));
             }
         }
 
-        found.Should().BeTrue("SourceInterfaces should is available as IMPLTYPEFLAG_FDEFAULT and IMPLTYPEFLAG_FSOURCE");
+        Assert.True(found);
     }
 
     [Fact]
@@ -341,7 +342,7 @@ public class ClassTest : BaseTest
                 .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestClass");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         using var typeAttr = typeInfo!.GetTypeInfoAttributes();
 
@@ -372,8 +373,8 @@ public class ClassTest : BaseTest
             }
         }
 
-        found.Should().Be(2, "SourceInterfaces should be availble two times");
-        foundIMPLTYPEFLAGFDEFAULT.Should().Be(1, "Multiple IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE found");
-        foundIMPLTYPEFLAGFSOURCE.Should().Be(1, "Multiple IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT found");
+        Assert.Equal(2, found);
+        Assert.Equal(1, foundIMPLTYPEFLAGFDEFAULT);
+        Assert.Equal(1, foundIMPLTYPEFLAGFSOURCE);
     }
 }

--- a/src/dscom.test/tests/ComVisibilityTest.cs
+++ b/src/dscom.test/tests/ComVisibilityTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Runtime.InteropServices;
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -45,7 +46,7 @@ public class ComVisibilityTest : BaseTest
         var result = typebuilder.Build().Build();
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
 
-        (typeInfo != null).Should().Be(interfaceCreated);
+        Assert.Equal(interfaceCreated, typeInfo != null);
     }
 
     [Fact]
@@ -60,7 +61,7 @@ public class ComVisibilityTest : BaseTest
                     .Build();
 
         using var property = result.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("TestProperty");
-        property.Should().BeNull("Property is ComVisible=false and should not be visible");
+        Assert.Null(property);
     }
 
     [Fact]
@@ -76,6 +77,6 @@ public class ComVisibilityTest : BaseTest
                     .Build();
 
         using var property = result.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("TestMethod");
-        property.Should().BeNull("Method is ComVisible=false and should not be visible");
+        Assert.Null(property);
     }
 }

--- a/src/dscom.test/tests/DefaultInterfaceTest.cs
+++ b/src/dscom.test/tests/DefaultInterfaceTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Runtime.InteropServices;
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -33,18 +34,18 @@ public class DefaultInterfaceTest : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestClass");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         using var typeAttr = typeInfo!.GetTypeInfoAttributes();
-        typeAttr!.Value.cImplTypes.Should().Be(2);
+        Assert.Equal(2, typeAttr!.Value.cImplTypes);
 
         typeInfo!.GetRefTypeOfImplType(0, out var href);
         typeInfo.GetRefTypeInfo(href, out var refTypeInfo);
         typeInfo.GetImplTypeFlags(0, out var pImplTypeFlags);
         refTypeInfo.GetDocumentation(-1, out var name, out _, out _, out _);
 
-        name.Should().Be("_TestClass");
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT);
+        Assert.Equal("_TestClass", name);
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT));
     }
 
     [Fact]
@@ -59,18 +60,18 @@ public class DefaultInterfaceTest : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestClass");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         using var typeAttr = typeInfo!.GetTypeInfoAttributes();
-        typeAttr!.Value.cImplTypes.Should().Be(2);
+        Assert.Equal(2, typeAttr!.Value.cImplTypes);
 
         typeInfo!.GetRefTypeOfImplType(1, out var href);
         typeInfo.GetRefTypeInfo(href, out var refTypeInfo);
         typeInfo.GetImplTypeFlags(1, out var pImplTypeFlags);
         refTypeInfo.GetDocumentation(-1, out var name, out _, out _, out _);
 
-        name.Should().Be(TestInterface);
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT);
+        Assert.Equal(TestInterface, name);
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT));
     }
 
     [Fact]
@@ -88,18 +89,18 @@ public class DefaultInterfaceTest : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestClass");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         using var typeAttr = typeInfo!.GetTypeInfoAttributes();
-        typeAttr!.Value.cImplTypes.Should().Be(2);
+        Assert.Equal(2, typeAttr!.Value.cImplTypes);
 
         typeInfo!.GetRefTypeOfImplType(0, out var href);
         typeInfo.GetRefTypeInfo(href, out var refTypeInfo);
         typeInfo.GetImplTypeFlags(0, out var pImplTypeFlags);
         refTypeInfo.GetDocumentation(-1, out var name, out _, out _, out _);
 
-        name.Should().Be("TestInterface1");
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT);
+        Assert.Equal("TestInterface1", name);
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT));
     }
 
     [Fact]
@@ -116,18 +117,18 @@ public class DefaultInterfaceTest : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("DerivedClass");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         using var typeAttr = typeInfo!.GetTypeInfoAttributes();
-        typeAttr!.Value.cImplTypes.Should().Be(2);
+        Assert.Equal(2, typeAttr!.Value.cImplTypes);
 
         typeInfo!.GetRefTypeOfImplType(0, out var href);
         typeInfo.GetRefTypeInfo(href, out var refTypeInfo);
         typeInfo.GetImplTypeFlags(0, out var pImplTypeFlags);
         refTypeInfo.GetDocumentation(-1, out var name, out _, out _, out _);
 
-        name.Should().Be("_DerivedClass");
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT);
+        Assert.Equal("_DerivedClass", name);
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT));
     }
 
     [Fact]
@@ -146,18 +147,18 @@ public class DefaultInterfaceTest : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("DerivedClass");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         using var typeAttr = typeInfo!.GetTypeInfoAttributes();
-        typeAttr!.Value.cImplTypes.Should().Be(3);
+        Assert.Equal(3, typeAttr!.Value.cImplTypes);
 
         typeInfo!.GetRefTypeOfImplType(1, out var href);
         typeInfo.GetRefTypeInfo(href, out var refTypeInfo);
         typeInfo.GetImplTypeFlags(1, out var pImplTypeFlags);
         refTypeInfo.GetDocumentation(-1, out var name, out _, out _, out _);
 
-        name.Should().Be(BaseInterface);
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT);
+        Assert.Equal(BaseInterface, name);
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT));
     }
 
     [Fact]
@@ -176,17 +177,17 @@ public class DefaultInterfaceTest : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("DerivedClass");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         using var typeAttr = typeInfo!.GetTypeInfoAttributes();
-        typeAttr!.Value.cImplTypes.Should().Be(2);
+        Assert.Equal(2, typeAttr!.Value.cImplTypes);
 
         typeInfo!.GetRefTypeOfImplType(1, out var href);
         typeInfo.GetRefTypeInfo(href, out var refTypeInfo);
         typeInfo.GetImplTypeFlags(1, out var pImplTypeFlags);
         refTypeInfo.GetDocumentation(-1, out var name, out _, out _, out _);
 
-        name.Should().Be(InterfaceName);
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT);
+        Assert.Equal(InterfaceName, name);
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT));
     }
 }

--- a/src/dscom.test/tests/EnumTest.cs
+++ b/src/dscom.test/tests/EnumTest.cs
@@ -14,6 +14,7 @@
 
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -39,13 +40,13 @@ public class EnumTest : BaseTest
             .Build();
 
         var typeLibInfo = result.TypeLib.GetTypeInfoByName("TestEnum");
-        typeLibInfo.Should().NotBeNull();
+        Assert.NotNull(typeLibInfo);
 
         var kv = typeLibInfo!.GetAllEnumValues();
 
-        kv.Should().Contain(new KeyValuePair<string, object>("TestEnum_A", 1));
-        kv.Should().Contain(new KeyValuePair<string, object>("TestEnum_B", 20));
-        kv.Should().Contain(new KeyValuePair<string, object>("TestEnum_C", 50));
+        Assert.Contains(new KeyValuePair<string, object>("TestEnum_A", 1), kv);
+        Assert.Contains(new KeyValuePair<string, object>("TestEnum_B", 20), kv);
+        Assert.Contains(new KeyValuePair<string, object>("TestEnum_C", 50), kv);
     }
 
     [Fact]
@@ -61,7 +62,7 @@ public class EnumTest : BaseTest
             .Build();
 
         var typeLibInfo = result.TypeLib.GetTypeInfoByName("TestEnum");
-        typeLibInfo.Should().BeNull();
+        Assert.Null(typeLibInfo);
     }
 
     [Fact]
@@ -79,20 +80,20 @@ public class EnumTest : BaseTest
             .Build();
 
         var typeLibInfo = result.TypeLib.GetTypeInfoByName("dspace_test_namespace1_TestEnum");
-        typeLibInfo.Should().NotBeNull();
+        Assert.NotNull(typeLibInfo);
         var kv = typeLibInfo!.GetAllEnumValues();
-        kv.ToList().Select(kv => kv.Key).Should().Contain("dspace_test_namespace1_TestEnum_A");
-        kv.ToList().Select(kv => kv.Key).Should().Contain("dspace_test_namespace1_TestEnum_B");
-        kv.ToList().Select(kv => kv.Key).Should().NotContain("TestEnum_A");
-        kv.ToList().Select(kv => kv.Key).Should().NotContain("TestEnum_B");
+        Assert.Contains("dspace_test_namespace1_TestEnum_A", kv.ToList().Select(kv => kv.Key));
+        Assert.Contains("dspace_test_namespace1_TestEnum_B", kv.ToList().Select(kv => kv.Key));
+        Assert.DoesNotContain("TestEnum_A", kv.ToList().Select(kv => kv.Key));
+        Assert.DoesNotContain("TestEnum_B", kv.ToList().Select(kv => kv.Key));
 
         typeLibInfo = result.TypeLib.GetTypeInfoByName("dspace_test_namespace2_TestEnum");
-        typeLibInfo.Should().NotBeNull();
+        Assert.NotNull(typeLibInfo);
         kv = typeLibInfo!.GetAllEnumValues();
-        kv.ToList().Select(kv => kv.Key).Should().Contain("dspace_test_namespace2_TestEnum_A");
-        kv.ToList().Select(kv => kv.Key).Should().Contain("dspace_test_namespace2_TestEnum_B");
-        kv.ToList().Select(kv => kv.Key).Should().NotContain("TestEnum_A");
-        kv.ToList().Select(kv => kv.Key).Should().NotContain("TestEnum_B");
+        Assert.Contains("dspace_test_namespace2_TestEnum_A", kv.ToList().Select(kv => kv.Key));
+        Assert.Contains("dspace_test_namespace2_TestEnum_B", kv.ToList().Select(kv => kv.Key));
+        Assert.DoesNotContain("TestEnum_A", kv.ToList().Select(kv => kv.Key));
+        Assert.DoesNotContain("TestEnum_B", kv.ToList().Select(kv => kv.Key));
     }
 
     [Fact]
@@ -106,19 +107,19 @@ public class EnumTest : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestEnum");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         using var attribute = typeInfo!.GetTypeInfoAttributes();
-        attribute.Should().NotBeNull();
+        Assert.NotNull(attribute);
         var count = attribute!.Value.cVars;
-        count.Should().Be(2);
+        Assert.Equal(2, count);
         typeInfo!.GetVarDesc(0, out var ppVarDesc0);
         try
         {
             var varDesc = Marshal.PtrToStructure<VARDESC>(ppVarDesc0);
-            varDesc.varkind.Should().Be(VARKIND.VAR_CONST);
+            Assert.Equal(VARKIND.VAR_CONST, varDesc.varkind);
             typeInfo!.GetDocumentation(varDesc.memid, out _, out var strDocString, out _, out _);
-            strDocString.Should().Be("TestDescription_A");
+            Assert.Equal("TestDescription_A", strDocString);
         }
         finally
         {
@@ -129,9 +130,9 @@ public class EnumTest : BaseTest
         try
         {
             var varDesc = Marshal.PtrToStructure<VARDESC>(ppVarDesc1);
-            varDesc.varkind.Should().Be(VARKIND.VAR_CONST);
+            Assert.Equal(VARKIND.VAR_CONST, varDesc.varkind);
             typeInfo!.GetDocumentation(varDesc.memid, out _, out var strDocString, out _, out _);
-            strDocString.Should().Be("TestDescription_B");
+            Assert.Equal("TestDescription_B", strDocString);
         }
         finally
         {

--- a/src/dscom.test/tests/EventTests.cs
+++ b/src/dscom.test/tests/EventTests.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 using System.Runtime.InteropServices;
-
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -32,20 +32,20 @@ public class EventTests : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("CustomClass");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         using var typeAttr = typeInfo!.GetTypeInfoAttributes();
 
-        typeAttr!.Value.cImplTypes.Should().Be(2);
+        Assert.Equal(2, typeAttr!.Value.cImplTypes);
 
         typeInfo!.GetRefTypeOfImplType(1, out var href);
         typeInfo.GetRefTypeInfo(href, out var refTypeInfo);
         typeInfo.GetImplTypeFlags(1, out var pImplTypeFlags);
         refTypeInfo.GetDocumentation(-1, out var name, out _, out _, out _);
 
-        name.Should().Be(EventInterface1);
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT);
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE);
+        Assert.Equal(EventInterface1, name);
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT));
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE));
     }
 
     [Fact]
@@ -59,20 +59,20 @@ public class EventTests : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("CustomClass");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         using var typeAttr = typeInfo!.GetTypeInfoAttributes();
 
-        typeAttr!.Value.cImplTypes.Should().Be(2);
+        Assert.Equal(2, typeAttr!.Value.cImplTypes);
 
         typeInfo!.GetRefTypeOfImplType(1, out var href);
         typeInfo.GetRefTypeInfo(href, out var refTypeInfo);
         typeInfo.GetImplTypeFlags(1, out var pImplTypeFlags);
         refTypeInfo.GetDocumentation(-1, out var name, out _, out _, out _);
 
-        name.Should().Be(EventInterface1);
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT);
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE);
+        Assert.Equal(EventInterface1, name);
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT));
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE));
     }
 
     [Fact]
@@ -88,28 +88,28 @@ public class EventTests : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("CustomClass");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         using var typeAttr = typeInfo!.GetTypeInfoAttributes();
 
-        typeAttr!.Value.cImplTypes.Should().Be(3);
+        Assert.Equal(3, typeAttr!.Value.cImplTypes);
 
         typeInfo!.GetRefTypeOfImplType(1, out var href);
         typeInfo.GetRefTypeInfo(href, out var refTypeInfo);
         typeInfo.GetImplTypeFlags(1, out var pImplTypeFlags);
         refTypeInfo.GetDocumentation(-1, out var name, out _, out _, out _);
 
-        name.Should().Be(EventInterface1);
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT);
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE);
+        Assert.Equal(EventInterface1, name);
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT));
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE));
 
         typeInfo!.GetRefTypeOfImplType(2, out href);
         typeInfo.GetRefTypeInfo(href, out refTypeInfo);
         typeInfo.GetImplTypeFlags(2, out pImplTypeFlags);
         refTypeInfo.GetDocumentation(-1, out name, out _, out _, out _);
 
-        name.Should().Be(EventInterface2);
-        pImplTypeFlags.Should().Be(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE);
+        Assert.Equal(EventInterface2, name);
+        Assert.Equal(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE, pImplTypeFlags);
     }
 
     [Fact]
@@ -123,28 +123,28 @@ public class EventTests : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("CustomClass");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         using var typeAttr = typeInfo!.GetTypeInfoAttributes();
 
-        typeAttr!.Value.cImplTypes.Should().Be(3);
+        Assert.Equal(3, typeAttr!.Value.cImplTypes);
 
         typeInfo!.GetRefTypeOfImplType(1, out var href);
         typeInfo.GetRefTypeInfo(href, out var refTypeInfo);
         typeInfo.GetImplTypeFlags(1, out var pImplTypeFlags);
         refTypeInfo.GetDocumentation(-1, out var name, out _, out _, out _);
 
-        name.Should().Be(EventInterface1);
-        pImplTypeFlags.Should().Be(0);
+        Assert.Equal(EventInterface1, name);
+        Assert.Equal(0, (int)pImplTypeFlags);
 
         typeInfo!.GetRefTypeOfImplType(2, out href);
         typeInfo.GetRefTypeInfo(href, out refTypeInfo);
         typeInfo.GetImplTypeFlags(2, out pImplTypeFlags);
         refTypeInfo.GetDocumentation(-1, out name, out _, out _, out _);
 
-        name.Should().Be(EventInterface1);
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT);
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE);
+        Assert.Equal(EventInterface1, name);
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT));
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE));
     }
 
     [Fact]
@@ -163,27 +163,27 @@ public class EventTests : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("CustomClass2");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         using var typeAttr = typeInfo!.GetTypeInfoAttributes();
 
-        typeAttr!.Value.cImplTypes.Should().Be(3);
+        Assert.Equal(3, typeAttr!.Value.cImplTypes);
 
         typeInfo!.GetRefTypeOfImplType(1, out var href);
         typeInfo.GetRefTypeInfo(href, out var refTypeInfo);
         typeInfo.GetImplTypeFlags(1, out var pImplTypeFlags);
         refTypeInfo.GetDocumentation(-1, out var name, out _, out _, out _);
 
-        name.Should().Be(EventInterface2);
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT);
-        pImplTypeFlags.Should().HaveFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE);
+        Assert.Equal(EventInterface2, name);
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT));
+        Assert.True(pImplTypeFlags.HasFlag(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE));
 
         typeInfo!.GetRefTypeOfImplType(2, out href);
         typeInfo.GetRefTypeInfo(href, out refTypeInfo);
         typeInfo.GetImplTypeFlags(2, out pImplTypeFlags);
         refTypeInfo.GetDocumentation(-1, out name, out _, out _, out _);
 
-        name.Should().Be(EventInterface1);
-        pImplTypeFlags.Should().Be(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE);
+        Assert.Equal(EventInterface1, name);
+        Assert.Equal(IMPLTYPEFLAGS.IMPLTYPEFLAG_FSOURCE, pImplTypeFlags);
     }
 }

--- a/src/dscom.test/tests/InterfaceTest.cs
+++ b/src/dscom.test/tests/InterfaceTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Runtime.InteropServices;
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -28,15 +29,14 @@ public class InterfaceTest : BaseTest
                         .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         using var attributes = typeInfo!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.typekind.Should().Be(TYPEKIND.TKIND_DISPATCH);
+        Assert.NotNull(attributes);
+        Assert.Equal(TYPEKIND.TKIND_DISPATCH, attributes!.Value.typekind);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
-
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -49,14 +49,14 @@ public class InterfaceTest : BaseTest
                         .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         using var attributes = typeInfo!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.typekind.Should().Be(TYPEKIND.TKIND_DISPATCH);
+        Assert.NotNull(attributes);
+        Assert.Equal(TYPEKIND.TKIND_DISPATCH, attributes!.Value.typekind);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -68,14 +68,14 @@ public class InterfaceTest : BaseTest
                         .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         using var attributes = typeInfo!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.typekind.Should().Be(TYPEKIND.TKIND_DISPATCH);
+        Assert.NotNull(attributes);
+        Assert.Equal(TYPEKIND.TKIND_DISPATCH, attributes!.Value.typekind);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -88,13 +88,13 @@ public class InterfaceTest : BaseTest
                         .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
         typeInfo!.GetDocumentation(-1, out _, out var strDocString, out _, out _);
-        strDocString.Should().NotBeNull();
-        strDocString.Should().BeEquivalentTo("Description");
+        Assert.NotNull(strDocString);
+        Assert.Equal("Description", strDocString);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -107,14 +107,14 @@ public class InterfaceTest : BaseTest
                         .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         using var attributes = typeInfo!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.wTypeFlags.Should().Be(TYPEFLAGS.TYPEFLAG_FDISPATCHABLE);
+        Assert.NotNull(attributes);
+        Assert.Equal(TYPEFLAGS.TYPEFLAG_FDISPATCHABLE, attributes!.Value.wTypeFlags);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -127,14 +127,14 @@ public class InterfaceTest : BaseTest
                         .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         using var attributes = typeInfo!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.wTypeFlags.Should().Be(TYPEFLAGS.TYPEFLAG_FDISPATCHABLE | TYPEFLAGS.TYPEFLAG_FDUAL);
+        Assert.NotNull(attributes);
+        Assert.Equal(TYPEFLAGS.TYPEFLAG_FDISPATCHABLE | TYPEFLAGS.TYPEFLAG_FDUAL, attributes!.Value.wTypeFlags);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -162,16 +162,16 @@ public class InterfaceTest : BaseTest
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
 
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         typeInfo!.GetRefTypeOfImplType(0, out var href);
         typeInfo!.GetRefTypeInfo(href, out var ppTI);
         ppTI.GetDocumentation(-1, out var refTypeName, out _, out _, out _);
 
-        refTypeName.Should().Be(expectedTypeString);
+        Assert.Equal(expectedTypeString, refTypeName);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -186,12 +186,11 @@ public class InterfaceTest : BaseTest
                         .Build()
                     .Build();
 
-        result.TypeLib.GetTypeInfoByName("Namespace1_TestInterface").Should().NotBeNull();
-        result.TypeLib.GetTypeInfoByName("Namespace2_TestInterface").Should().NotBeNull();
-
-        result.TypeLib.GetTypeInfoByName("TestInterface").Should().BeNull();
+        Assert.NotNull(result.TypeLib.GetTypeInfoByName("Namespace1_TestInterface"));
+        Assert.NotNull(result.TypeLib.GetTypeInfoByName("Namespace2_TestInterface"));
+        Assert.Null(result.TypeLib.GetTypeInfoByName("TestInterface"));
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 }

--- a/src/dscom.test/tests/MarshalAsTest.cs
+++ b/src/dscom.test/tests/MarshalAsTest.cs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 using System.Runtime.InteropServices;
+using System.Security.Principal;
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -39,7 +41,7 @@ public class MarshalAsTest : BaseTest
         var result = interface2.Build().Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface should be generated");
+        Assert.NotNull(typeInfo);
 
         foreach (var kv in MarshalHelper.UnmanagedTypeMapDict)
         {
@@ -49,16 +51,16 @@ public class MarshalAsTest : BaseTest
             if (kv.Value == null)
             {
                 // Is not supported TLBX_E_BAD_NATIVETYPE
-                funcDesc.Should().BeNull($"{methodName} should not no be available");
+                Assert.Null(funcDesc);
             }
             else
             {
                 // Is is supported
-                funcDesc.Should().NotBeNull($"{methodName} should be available");
+                Assert.NotNull(funcDesc);
 
                 // check first parameter
                 var firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDesc!.Value.lprgelemdescParam);
-                firstParam.tdesc.GetVarEnum().Should().Be(kv.Value, $"First parameter of {methodName} should be available {kv.Value}");
+                Assert.Equal(kv.Value, firstParam.tdesc.GetVarEnum());
             }
         }
     }
@@ -83,7 +85,7 @@ public class MarshalAsTest : BaseTest
         var result = type.Build().Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface should be generated");
+        Assert.NotNull(typeInfo);
 
         foreach (var kv in MarshalHelper.UnmanagedTypeMapDict)
         {
@@ -95,16 +97,16 @@ public class MarshalAsTest : BaseTest
             if (kv.Value == null)
             {
                 // Is not supported TLBX_E_BAD_NATIVETYPE
-                funcDescSet.Should().BeNull($"{methodName} should not no be available");
+                Assert.Null(funcDescSet);
             }
             else
             {
                 // Is is supported
-                funcDescSet.Should().NotBeNull($"{methodName} should be available");
+                Assert.NotNull(funcDescSet);
 
                 // check first parameter
                 var firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDescSet!.Value.lprgelemdescParam);
-                firstParam.tdesc.GetVarEnum().Should().Be(kv.Value, $"First parameter of {methodName} should be available {kv.Value}");
+                Assert.Equal(kv.Value, firstParam.tdesc.GetVarEnum());
             }
 
             // Check getter
@@ -113,26 +115,26 @@ public class MarshalAsTest : BaseTest
             if (kv.Value == null)
             {
                 // Is not supported TLBX_E_BAD_NATIVETYPE
-                funcDescGet.Should().BeNull($"{methodName} should not no be available");
+                Assert.Null(funcDescGet);
             }
             else
             {
                 // Is is supported
-                funcDescGet.Should().NotBeNull($"{methodName} should be available");
+                Assert.NotNull(funcDescGet);
 
                 if (interfaceType == ComInterfaceType.InterfaceIsIUnknown)
                 {
                     // Return type should be VT_HRESULT
-                    funcDescGet!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(VarEnum.VT_HRESULT, $"Return type of {methodName} should be available {kv.Value}");
+                    Assert.Equal(VarEnum.VT_HRESULT, funcDescGet!.Value.elemdescFunc.tdesc.GetVarEnum());
 
                     // check first parameter
                     var firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDescSet!.Value.lprgelemdescParam);
-                    firstParam.tdesc.GetVarEnum().Should().Be(kv.Value, $"First parameter of {methodName} should be available {kv.Value}");
+                    Assert.Equal(kv.Value, firstParam.tdesc.GetVarEnum());
                 }
                 else
                 {
                     // Check return value
-                    funcDescGet!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(kv.Value, $"Return type of {methodName} should be available {kv.Value}");
+                    Assert.Equal(kv.Value, funcDescGet!.Value.elemdescFunc.tdesc.GetVarEnum());
                 }
             }
         }
@@ -156,7 +158,7 @@ public class MarshalAsTest : BaseTest
         var result = interface2.Build().Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface should be generated");
+        Assert.NotNull(typeInfo);
 
         foreach (var kv in MarshalHelper.UnmanagedTypeMapDict)
         {
@@ -166,23 +168,23 @@ public class MarshalAsTest : BaseTest
             if (kv.Value == null)
             {
                 // Is not supported TLBX_E_BAD_NATIVETYPE
-                funcDesc.Should().BeNull($"{methodName} should not no be available");
+                Assert.Null(funcDesc);
             }
             else
             {
                 // Is is supported
-                funcDesc.Should().NotBeNull($"{methodName} should be available");
+                Assert.NotNull(funcDesc);
 
                 // return value should be VT_HRESULT
-                funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(VarEnum.VT_HRESULT, $"Return value of {methodName} should be available and VarEnum.VT_HRESULT");
+                Assert.Equal(VarEnum.VT_HRESULT, funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum());
 
                 // first parameter should be VT_PTR
                 var firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDesc!.Value.lprgelemdescParam);
-                firstParam.tdesc.GetVarEnum().Should().Be(VarEnum.VT_PTR, $"First parameter of {methodName} should be available VarEnum.VT_PTR");
+                Assert.Equal(VarEnum.VT_PTR, firstParam.tdesc.GetVarEnum());
 
                 // first parameter inner type
                 var subtypeDesc = Marshal.PtrToStructure<TYPEDESC>(firstParam.tdesc.lpValue);
-                subtypeDesc.GetVarEnum().Should().Be(kv.Value, $"First parameter of {methodName} should be available VarEnum.VT_PTR");
+                Assert.Equal(kv.Value, subtypeDesc.GetVarEnum());
             }
         }
     }
@@ -237,14 +239,13 @@ public class MarshalAsTest : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface should be generated");
+        Assert.NotNull(typeInfo);
+
         using var funcDesc = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDesc.Should().NotBeNull("TestMethod should be available");
-        funcDesc!.Value.cParams.Should().Be(0);
-
-        funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(varEnumType, $"First Parameter type of TestMethod should be {varEnumType}");
-
-        result.TypeLibExporterNotifySink.ReportedEvents.Count.Should().Be(1);
+        Assert.NotNull(funcDesc);
+        Assert.Equal(0, funcDesc!.Value.cParams);
+        Assert.Equal(varEnumType, funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum());
+        Assert.Single(result.TypeLibExporterNotifySink.ReportedEvents);
     }
 
     [Theory]
@@ -266,7 +267,7 @@ public class MarshalAsTest : BaseTest
         var result = interface2.Build().Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface should be generated");
+        Assert.NotNull(typeInfo);
 
         foreach (var kv in MarshalHelper.UnmanagedTypeMapDict)
         {
@@ -276,15 +277,15 @@ public class MarshalAsTest : BaseTest
             if (kv.Value == null)
             {
                 // Is not supported TLBX_E_BAD_NATIVETYPE
-                funcDesc.Should().BeNull($"{methodName} should not no be available");
+                Assert.Null(funcDesc);
             }
             else
             {
                 // Is is supported
-                funcDesc.Should().NotBeNull($"{methodName} should be available");
+                Assert.NotNull(funcDesc);
 
                 // check return value
-                funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(kv.Value, $"First parameter of {methodName} should be available {kv.Value}");
+                Assert.Equal(kv.Value, funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum());
             }
         }
     }
@@ -326,13 +327,13 @@ public class MarshalAsTest : BaseTest
         var result = interface2.Build().Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface should be generated");
+        Assert.NotNull(typeInfo);
 
         foreach (var kv in MarshalHelper.UnmanagedTypeMapDict)
         {
             var methodName = ValidChars.Replace($"TestMethod_ArrayIs_{kv.Key.Type}_SubTypeIs_{enumSubType}_Expected_SAFEARRAY", "_");
             using var funcDesc = typeInfo!.GetFuncDescByName(methodName);
-            funcDesc.Should().BeNull();
+            Assert.Null(funcDesc);
         }
     }
 
@@ -406,7 +407,7 @@ public class MarshalAsTest : BaseTest
         var result = interface2.Build().Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface should be generated");
+        Assert.NotNull(typeInfo);
 
         foreach (var parameterType in MarshalHelper.UnmanagedTypeMapDict.Keys.Select(y => y.Type).Distinct())
         {
@@ -417,16 +418,16 @@ public class MarshalAsTest : BaseTest
             if (parameterType.IsArray)
             {
                 // Is not supported TLBX_E_BAD_NATIVETYPE
-                funcDesc.Should().BeNull($"{methodName} should not no be available");
+                Assert.Null(funcDesc);
             }
             else
             {
                 // Is is supported
-                funcDesc.Should().NotBeNull($"{methodName} should be available");
+                Assert.NotNull(funcDesc);
 
                 // check first parameter
                 var firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDesc!.Value.lprgelemdescParam);
-                firstParam.tdesc.GetVarEnum().Should().Be(VarEnum.VT_SAFEARRAY, $"First parameter of {methodName} should be available VarEnum.VT_SAFEARRAY");
+                Assert.Equal(VarEnum.VT_SAFEARRAY, firstParam.tdesc.GetVarEnum());
                 var firstParamSub = Marshal.PtrToStructure<ELEMDESC>(firstParam.tdesc.lpValue);
                 if (firstParamSub.tdesc.lpValue != IntPtr.Zero && firstParamSub.tdesc.GetVarEnum() == VarEnum.VT_PTR)
                 {
@@ -434,11 +435,11 @@ public class MarshalAsTest : BaseTest
                 }
                 if (enumSubType is VarEnum.VT_USERDEFINED or VarEnum.VT_EMPTY)
                 {
-                    firstParamSub.tdesc.GetVarEnum().Should().Be(MarshalHelper.TypeToVarEnum(parameterType), $"Sub parameter of {methodName} should be {MarshalHelper.TypeToVarEnum(parameterType)}");
+                    Assert.Equal(MarshalHelper.TypeToVarEnum(parameterType), firstParamSub.tdesc.GetVarEnum());
                 }
                 else
                 {
-                    firstParamSub.tdesc.GetVarEnum().Should().Be(enumSubType, $"Sub parameter of {methodName} should be {enumSubType}");
+                    Assert.Equal(enumSubType, firstParamSub.tdesc.GetVarEnum());
                 }
             }
         }
@@ -475,7 +476,7 @@ public class MarshalAsTest : BaseTest
         var result = builder.Build().Build();
 
         var typeinfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeinfo.Should().NotBeNull();
+        Assert.NotNull(typeinfo);
 
         foreach (UnmanagedType value in Enum.GetValues(typeof(UnmanagedType)))
         {
@@ -490,22 +491,22 @@ public class MarshalAsTest : BaseTest
             var methodName = $"TestMethod_{value}";
             var funcDesc = typeinfo!.GetFuncDescByName(methodName);
 
-            funcDesc.Should().NotBeNull();
+            Assert.NotNull(funcDesc);
 
             // return value should be VT_PTR
-            funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(VarEnum.VT_PTR, $"Return value of {methodName} should be available and VarEnum.VT_HRESULT");
+            Assert.Equal(VarEnum.VT_PTR, funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum());
 
             // return value inner type should VT_USERDEFINED
             var subtypeDesc = Marshal.PtrToStructure<TYPEDESC>(funcDesc!.Value.elemdescFunc.tdesc.lpValue);
-            subtypeDesc.GetVarEnum().Should().Be(VarEnum.VT_USERDEFINED, $"First parameter of {methodName} should be available VarEnum.VT_PTR");
+            Assert.Equal(VarEnum.VT_USERDEFINED, subtypeDesc.GetVarEnum());
 
             // first parameter should be VT_PTR
             var firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDesc!.Value.lprgelemdescParam);
-            firstParam.tdesc.GetVarEnum().Should().Be(VarEnum.VT_PTR, $"First parameter of {methodName} should be available VarEnum.VT_PTR");
+            Assert.Equal(VarEnum.VT_PTR, firstParam.tdesc.GetVarEnum());
 
             // first parameter inner type should be VT_USERDEFINED
             subtypeDesc = Marshal.PtrToStructure<TYPEDESC>(firstParam.tdesc.lpValue);
-            subtypeDesc.GetVarEnum().Should().Be(VarEnum.VT_USERDEFINED, $"First parameter of {methodName} should be available VarEnum.VT_PTR");
+            Assert.Equal(VarEnum.VT_USERDEFINED, subtypeDesc.GetVarEnum());
         }
     }
 
@@ -526,9 +527,9 @@ public class MarshalAsTest : BaseTest
                         .Build();
 
         var type = result.TypeLib.GetTypeInfoByName("TestInterface");
-        type.Should().NotBeNull();
+        Assert.NotNull(type);
 
-        type!.GetFuncDescByName("TestMethod").Should().NotBeNull("TestMethod should be available");
+        Assert.NotNull(type!.GetFuncDescByName("TestMethod"));
     }
 
     [Theory]
@@ -560,32 +561,32 @@ public class MarshalAsTest : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface should be generated");
+        Assert.NotNull(typeInfo);
 
         // Check setter
         using var funcDescSet = typeInfo!.GetFuncDescByName("TestProperty", INVOKEKIND.INVOKE_PROPERTYPUT | INVOKEKIND.INVOKE_PROPERTYPUTREF);
 
         // check first parameter
         var firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDescSet!.Value.lprgelemdescParam);
-        firstParam.tdesc.GetVarEnum().Should().Be(resultType);
+        Assert.Equal(resultType, firstParam.tdesc.GetVarEnum());
 
         // Check getter
         using var funcDescGet = typeInfo!.GetFuncDescByName("TestProperty", INVOKEKIND.INVOKE_PROPERTYGET);
-        funcDescGet.Should().NotBeNull();
+        Assert.NotNull(funcDescGet);
 
         if (interfaceType == ComInterfaceType.InterfaceIsIUnknown)
         {
             // Return type should be VT_HRESULT
-            funcDescGet!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(VarEnum.VT_HRESULT);
+            Assert.Equal(VarEnum.VT_HRESULT, funcDescGet!.Value.elemdescFunc.tdesc.GetVarEnum());
 
             // check first parameter
             firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDescSet!.Value.lprgelemdescParam);
-            firstParam.tdesc.GetVarEnum().Should().Be(resultType);
+            Assert.Equal(resultType, firstParam.tdesc.GetVarEnum());
         }
         else
         {
             // Check return value
-            funcDescGet!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(resultType);
+            Assert.Equal(resultType, funcDescGet!.Value.elemdescFunc.tdesc.GetVarEnum());
         }
     }
 
@@ -618,14 +619,14 @@ public class MarshalAsTest : BaseTest
             .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
         // Check setter
         using var funcDescSet = typeInfo!.GetFuncDescByName("TestProperty", INVOKEKIND.INVOKE_PROPERTYPUT | INVOKEKIND.INVOKE_PROPERTYPUTREF);
-        funcDescSet.Should().BeNull();
+        Assert.Null(funcDescSet);
 
         // Check getter
         using var funcDescGet = typeInfo!.GetFuncDescByName("TestProperty", INVOKEKIND.INVOKE_PROPERTYGET);
-        funcDescGet.Should().BeNull();
+        Assert.Null(funcDescGet);
     }
 }

--- a/src/dscom.test/tests/MemIdTest.cs
+++ b/src/dscom.test/tests/MemIdTest.cs
@@ -14,6 +14,7 @@
 
 using System.Collections;
 using System.Runtime.InteropServices;
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -38,13 +39,13 @@ public class MemIdTest : BaseTest
         using var property2 = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("Property2");
         using var property3 = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("Property3");
 
-        property1.Should().NotBeNull("Property1 property should be available");
-        property2.Should().NotBeNull("Property2 property should be available");
-        property3.Should().NotBeNull("Property3 property should be available");
+        Assert.NotNull(property1);
+        Assert.NotNull(property2);
+        Assert.NotNull(property3);
 
-        property1!.Value.memid.Should().Be(dispIdStart);
-        property2!.Value.memid.Should().Be(dispIdStart + 2);
-        property3!.Value.memid.Should().Be(dispIdStart + 4);
+        Assert.Equal(dispIdStart, property1!.Value.memid);
+        Assert.Equal(dispIdStart + 2, property2!.Value.memid);
+        Assert.Equal(dispIdStart + 4, property3!.Value.memid);
     }
 
     [Theory]
@@ -66,13 +67,13 @@ public class MemIdTest : BaseTest
         using var method2 = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("Method2");
         using var method3 = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("Method3");
 
-        method1.Should().NotBeNull("Method1 method should be available");
-        method2.Should().NotBeNull("Method2 method should be available");
-        method3.Should().NotBeNull("Method3 method should be available");
+        Assert.NotNull(method1);
+        Assert.NotNull(method2);
+        Assert.NotNull(method3);
 
-        method1!.Value.memid.Should().Be(dispIdStart);
-        method2!.Value.memid.Should().Be(dispIdStart + 1);
-        method3!.Value.memid.Should().Be(dispIdStart + 2);
+        Assert.Equal(dispIdStart, method1!.Value.memid);
+        Assert.Equal(dispIdStart + 1, method2!.Value.memid);
+        Assert.Equal(dispIdStart + 2, method3!.Value.memid);
     }
 
     [Theory]
@@ -94,11 +95,11 @@ public class MemIdTest : BaseTest
         using var method1 = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("Method1");
         using var method2 = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("Method2");
 
-        method1.Should().NotBeNull("Method1 method should be available");
-        method2.Should().NotBeNull("Method2 method should be available");
+        Assert.NotNull(method1);
+        Assert.NotNull(method2);
 
-        method1!.Value.memid.Should().Be(dispIdStart + 1);
-        method2!.Value.memid.Should().Be(dispIdStart + 2);
+        Assert.Equal(dispIdStart + 1, method1!.Value.memid);
+        Assert.Equal(dispIdStart + 2, method2!.Value.memid);
     }
 
     [Fact]
@@ -112,9 +113,8 @@ public class MemIdTest : BaseTest
                     .Build();
 
         using var func = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("GetEnumerator");
-        func.Should().NotBeNull("GetEnumerator method should be available");
-
-        func!.Value.memid.Should().Be(-4);
+        Assert.NotNull(func);
+        Assert.Equal(-4, func!.Value.memid);
     }
 
     [Fact]
@@ -130,9 +130,8 @@ public class MemIdTest : BaseTest
                     .Build();
 
         using var func = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("GetEnumerator");
-        func.Should().NotBeNull("GetEnumerator method should be available");
-
-        func!.Value.memid.Should().Be(123);
+        Assert.NotNull(func);
+        Assert.Equal(123, func!.Value.memid);
     }
 
     [Fact]
@@ -147,9 +146,8 @@ public class MemIdTest : BaseTest
                     .Build();
 
         using var func = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("GetEnumerator2");
-        func.Should().NotBeNull("GetEnumerator2 method should be available");
-
-        func!.Value.memid.Should().NotBe(-4);
+        Assert.NotNull(func);
+        Assert.NotEqual(-4, func!.Value.memid);
     }
 
     [Fact]
@@ -164,9 +162,8 @@ public class MemIdTest : BaseTest
                     .Build();
 
         using var func = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("GetEnumerator");
-        func.Should().NotBeNull("GetEnumerator method should be available");
-
-        func!.Value.memid.Should().NotBe(-4);
+        Assert.NotNull(func);
+        Assert.NotEqual(-4, func!.Value.memid);
     }
 
     [Fact]
@@ -180,9 +177,8 @@ public class MemIdTest : BaseTest
                     .Build();
 
         using var func = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("Value");
-        func.Should().NotBeNull("Value property should be available");
-
-        func!.Value.memid.Should().Be(0);
+        Assert.NotNull(func);
+        Assert.Equal(0, func!.Value.memid);
     }
 
     [Fact]
@@ -197,9 +193,8 @@ public class MemIdTest : BaseTest
                     .Build();
 
         using var func = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("Value");
-        func.Should().NotBeNull("Value property should be available");
-
-        func!.Value.memid.Should().Be(123);
+        Assert.NotNull(func);
+        Assert.Equal(123, func!.Value.memid);
     }
 
     [Fact]
@@ -214,9 +209,8 @@ public class MemIdTest : BaseTest
                     .Build();
 
         using var func = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("Value");
-        func.Should().NotBeNull("Value property should be available");
-
-        func!.Value.memid.Should().NotBe(0);
+        Assert.NotNull(func);
+        Assert.NotEqual(0, func!.Value.memid);
     }
 
     [Fact]
@@ -232,9 +226,8 @@ public class MemIdTest : BaseTest
                     .Build();
 
         using var func = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("Item");
-        func.Should().NotBeNull("Item method should be available");
-
-        func!.Value.memid.Should().Be(123);
+        Assert.NotNull(func);
+        Assert.Equal(123, func!.Value.memid);
     }
 
     [Fact]
@@ -252,15 +245,15 @@ public class MemIdTest : BaseTest
                     .Build();
 
         using var property1 = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("Property1");
-        property1.Should().NotBeNull("Property1 property should be available");
+        Assert.NotNull(property1);
 
         using var property2 = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("Property2");
-        property2.Should().NotBeNull("Property2 property should be available");
+        Assert.NotNull(property2);
 
-        property1!.Value.memid.Should().NotBe(123);
-        property2!.Value.memid.Should().NotBe(123);
+        Assert.NotEqual(123, property1!.Value.memid);
+        Assert.NotEqual(123, property2!.Value.memid);
 
-        property1!.Value.memid.Should().NotBe(property2!.Value.memid);
+        Assert.NotEqual(property1!.Value.memid, property2!.Value.memid);
     }
 
     [Fact]
@@ -275,8 +268,8 @@ public class MemIdTest : BaseTest
                     .Build();
 
         using var valueProperty = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("DefaultProperty");
-        valueProperty.Should().NotBeNull("DefaultProperty property should be available");
-        valueProperty!.Value.memid.Should().Be(0);
+        Assert.NotNull(valueProperty);
+        Assert.Equal(0, valueProperty!.Value.memid);
     }
 
     [Fact]
@@ -296,9 +289,9 @@ public class MemIdTest : BaseTest
         new List<string> { "TestProperty1", "TestProperty2" }.ForEach(propertyName =>
         {
             using var releasableFuncDesc = result.TypeLib.GetTypeInfoByName("TestInterface")?.GetFuncDescByName(propertyName);
-            releasableFuncDesc.Should().NotBeNull();
-            releasableFuncDesc!.Value.invkind.Should().Be(INVOKEKIND.INVOKE_PROPERTYGET);
-            releasableFuncDesc!.Value.memid.Should().NotBe(99);
+            Assert.NotNull(releasableFuncDesc);
+            Assert.Equal(INVOKEKIND.INVOKE_PROPERTYGET, releasableFuncDesc!.Value.invkind);
+            Assert.NotEqual(99, releasableFuncDesc!.Value.memid);
         });
     }
 
@@ -313,9 +306,9 @@ public class MemIdTest : BaseTest
                     .Build();
 
         using var releasableFuncDesc = result.TypeLib.GetTypeInfoByName("TestInterface")?.GetFuncDescByName("TestProperty");
-        releasableFuncDesc.Should().NotBeNull();
-        releasableFuncDesc!.Value.invkind.Should().Be(INVOKEKIND.INVOKE_PROPERTYGET);
-        releasableFuncDesc!.Value.memid.Should().NotBe(0);
+        Assert.NotNull(releasableFuncDesc);
+        Assert.Equal(INVOKEKIND.INVOKE_PROPERTYGET, releasableFuncDesc!.Value.invkind);
+        Assert.NotEqual(0, releasableFuncDesc!.Value.memid);
     }
 
     [Fact]
@@ -330,9 +323,9 @@ public class MemIdTest : BaseTest
                     .Build();
 
         using var releasableFuncDesc = result.TypeLib.GetTypeInfoByName("TestInterface")?.GetFuncDescByName("TestProperty");
-        releasableFuncDesc.Should().NotBeNull();
-        releasableFuncDesc!.Value.invkind.Should().Be(INVOKEKIND.INVOKE_PROPERTYGET);
-        releasableFuncDesc!.Value.memid.Should().Be(99);
+        Assert.NotNull(releasableFuncDesc);
+        Assert.Equal(INVOKEKIND.INVOKE_PROPERTYGET, releasableFuncDesc!.Value.invkind);
+        Assert.Equal(99, releasableFuncDesc!.Value.memid);
     }
 
     [Fact]
@@ -352,9 +345,9 @@ public class MemIdTest : BaseTest
         new List<string> { "TestMethod1", "TestMethod2" }.ForEach(propertyName =>
         {
             using var releasableFuncDesc = result.TypeLib.GetTypeInfoByName("TestInterface")?.GetFuncDescByName(propertyName);
-            releasableFuncDesc.Should().NotBeNull();
-            releasableFuncDesc!.Value.invkind.Should().Be(INVOKEKIND.INVOKE_FUNC);
-            releasableFuncDesc!.Value.memid.Should().NotBe(99);
+            Assert.NotNull(releasableFuncDesc);
+            Assert.Equal(INVOKEKIND.INVOKE_FUNC, releasableFuncDesc!.Value.invkind);
+            Assert.NotEqual(99, releasableFuncDesc!.Value.memid);
         });
     }
 
@@ -370,9 +363,9 @@ public class MemIdTest : BaseTest
                     .Build();
 
         using var releasableFuncDesc = result.TypeLib.GetTypeInfoByName("TestInterface")?.GetFuncDescByName("TestMethod");
-        releasableFuncDesc.Should().NotBeNull();
-        releasableFuncDesc!.Value.invkind.Should().Be(INVOKEKIND.INVOKE_FUNC);
-        releasableFuncDesc!.Value.memid.Should().NotBe(0);
+        Assert.NotNull(releasableFuncDesc);
+        Assert.Equal(INVOKEKIND.INVOKE_FUNC, releasableFuncDesc!.Value.invkind);
+        Assert.NotEqual(0, releasableFuncDesc!.Value.memid);
     }
 
     [Fact]
@@ -388,9 +381,9 @@ public class MemIdTest : BaseTest
                     .Build();
 
         using var releasableFuncDesc = result.TypeLib.GetTypeInfoByName("TestInterface")?.GetFuncDescByName("TestMethod");
-        releasableFuncDesc.Should().NotBeNull();
-        releasableFuncDesc!.Value.invkind.Should().Be(INVOKEKIND.INVOKE_FUNC);
-        releasableFuncDesc!.Value.memid.Should().Be(99);
+        Assert.NotNull(releasableFuncDesc);
+        Assert.Equal(INVOKEKIND.INVOKE_FUNC, releasableFuncDesc!.Value.invkind);
+        Assert.Equal(99, releasableFuncDesc!.Value.memid);
     }
 
     [Fact]
@@ -406,22 +399,22 @@ public class MemIdTest : BaseTest
                     .Build();
 
         var testInterface = result!.TypeLib.GetTypeInfoByName("TestInterface");
-        testInterface.Should().NotBeNull();
+        Assert.NotNull(testInterface);
 
         using var attributes = testInterface!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.cbSizeVft.Should().Be(48);
+        Assert.NotNull(attributes);
+        Assert.Equal(48, attributes!.Value.cbSizeVft);
 
         using var method1 = testInterface!.GetFuncDescByName("Method1");
-        method1.Should().NotBeNull();
-        method1!.Value.oVft.Should().Be(24);
+        Assert.NotNull(method1);
+        Assert.Equal(24, method1!.Value.oVft);
 
         using var method2 = testInterface!.GetFuncDescByName("Method2");
-        method2.Should().BeNull();
+        Assert.Null(method2);
 
         using var method3 = testInterface!.GetFuncDescByName("Method3");
-        method3.Should().NotBeNull();
-        method3!.Value.oVft.Should().Be(40);
+        Assert.NotNull(method3);
+        Assert.Equal(40, method3!.Value.oVft);
     }
 
     [Fact]
@@ -437,22 +430,22 @@ public class MemIdTest : BaseTest
                     .Build();
 
         var testInterface = result!.TypeLib.GetTypeInfoByName("TestInterface");
-        testInterface.Should().NotBeNull();
+        Assert.NotNull(testInterface);
 
         using var attributes = testInterface!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.cbSizeVft.Should().Be(72);
+        Assert.NotNull(attributes);
+        Assert.Equal(72, attributes!.Value.cbSizeVft);
 
         using var method1 = testInterface!.GetFuncDescByName("Property1");
-        method1.Should().NotBeNull();
-        method1!.Value.oVft.Should().Be(24);
+        Assert.NotNull(method1);
+        Assert.Equal(24, method1!.Value.oVft);
 
         using var method2 = testInterface!.GetFuncDescByName("Property2");
-        method2.Should().BeNull();
+        Assert.Null(method2);
 
         using var method3 = testInterface!.GetFuncDescByName("Property3", INVOKEKIND.INVOKE_PROPERTYGET);
-        method3.Should().NotBeNull();
-        method3!.Value.oVft.Should().Be(56);
+        Assert.NotNull(method3);
+        Assert.Equal(56, method3!.Value.oVft);
     }
 
     [Fact]
@@ -468,24 +461,24 @@ public class MemIdTest : BaseTest
                     .Build();
 
         var testInterface = result!.TypeLib.GetTypeInfoByName("TestInterface");
-        testInterface.Should().NotBeNull();
+        Assert.NotNull(testInterface);
 
         using var attributes = testInterface!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.cbSizeVft.Should().Be(56);
+        Assert.NotNull(attributes);
+        Assert.Equal(56, attributes!.Value.cbSizeVft);
 
         using var method1 = testInterface!.GetFuncDescByName("Method1");
-        method1.Should().NotBeNull();
-        method1!.Value.oVft.Should().Be(0);
-        method1!.Value.memid.Should().Be((int)Constants.BASE_OLEAUT_DISPID);
+        Assert.NotNull(method1);
+        Assert.Equal(0, method1!.Value.oVft);
+        Assert.Equal((int)Constants.BASE_OLEAUT_DISPID, method1!.Value.memid);
 
         using var method2 = testInterface!.GetFuncDescByName("Method2");
-        method2.Should().BeNull();
+        Assert.Null(method2);
 
         using var method3 = testInterface!.GetFuncDescByName("Method3");
-        method3.Should().NotBeNull();
-        method3!.Value.oVft.Should().Be(0);
-        method3!.Value.memid.Should().Be(((int)Constants.BASE_OLEAUT_DISPID) + 2);
+        Assert.NotNull(method3);
+        Assert.Equal(0, method3!.Value.oVft);
+        Assert.Equal(((int)Constants.BASE_OLEAUT_DISPID) + 2, method3!.Value.memid);
     }
 
     [Fact]
@@ -501,24 +494,24 @@ public class MemIdTest : BaseTest
                     .Build();
 
         var testInterface = result!.TypeLib.GetTypeInfoByName("TestInterface");
-        testInterface.Should().NotBeNull();
+        Assert.NotNull(testInterface);
 
         using var attributes = testInterface!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.cbSizeVft.Should().Be(56);
+        Assert.NotNull(attributes);
+        Assert.Equal(56, attributes!.Value.cbSizeVft);
 
         using var method1 = testInterface!.GetFuncDescByName("Property1");
-        method1.Should().NotBeNull();
-        method1!.Value.oVft.Should().Be(0);
-        method1!.Value.memid.Should().Be((int)Constants.BASE_OLEAUT_DISPID);
+        Assert.NotNull(method1);
+        Assert.Equal(0, method1!.Value.oVft);
+        Assert.Equal((int)Constants.BASE_OLEAUT_DISPID, method1!.Value.memid);
 
         using var method2 = testInterface!.GetFuncDescByName("Property2");
-        method2.Should().BeNull();
+        Assert.Null(method2);
 
         using var method3 = testInterface!.GetFuncDescByName("Property3", INVOKEKIND.INVOKE_PROPERTYGET);
-        method3.Should().NotBeNull();
-        method3!.Value.oVft.Should().Be(0);
-        method3!.Value.memid.Should().Be(((int)Constants.BASE_OLEAUT_DISPID) + 4);
+        Assert.NotNull(method3);
+        Assert.Equal(0, method3!.Value.oVft);
+        Assert.Equal(((int)Constants.BASE_OLEAUT_DISPID) + 4, method3!.Value.memid);
     }
 
     [Fact]
@@ -534,24 +527,24 @@ public class MemIdTest : BaseTest
                     .Build();
 
         var testInterface = result!.TypeLib.GetTypeInfoByName("TestInterface");
-        testInterface.Should().NotBeNull();
+        Assert.NotNull(testInterface);
 
         using var attributes = testInterface!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.cbSizeVft.Should().Be(56);
+        Assert.NotNull(attributes);
+        Assert.Equal(56, attributes!.Value.cbSizeVft);
 
         using var method1 = testInterface!.GetFuncDescByName("Method1");
-        method1.Should().NotBeNull();
-        method1!.Value.oVft.Should().Be(56);
-        method1!.Value.memid.Should().Be((int)Constants.BASE_OLEAUT_DISPID);
+        Assert.NotNull(method1);
+        Assert.Equal(56, method1!.Value.oVft);
+        Assert.Equal((int)Constants.BASE_OLEAUT_DISPID, method1!.Value.memid);
 
         using var method2 = testInterface!.GetFuncDescByName("Method2");
-        method2.Should().BeNull();
+        Assert.Null(method2);
 
         using var method3 = testInterface!.GetFuncDescByName("Method3");
-        method3.Should().NotBeNull();
-        method3!.Value.oVft.Should().Be(72);
-        method3!.Value.memid.Should().Be(((int)Constants.BASE_OLEAUT_DISPID) + 2);
+        Assert.NotNull(method3);
+        Assert.Equal(72, method3!.Value.oVft);
+        Assert.Equal(((int)Constants.BASE_OLEAUT_DISPID) + 2, method3!.Value.memid);
     }
 
     [Fact]
@@ -567,24 +560,24 @@ public class MemIdTest : BaseTest
                     .Build();
 
         var testInterface = result!.TypeLib.GetTypeInfoByName("TestInterface");
-        testInterface.Should().NotBeNull();
+        Assert.NotNull(testInterface);
 
         using var attributes = testInterface!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
-        attributes!.Value.cbSizeVft.Should().Be(56);
+        Assert.NotNull(attributes);
+        Assert.Equal(56, attributes!.Value.cbSizeVft);
 
         using var method1 = testInterface!.GetFuncDescByName("Property1");
-        method1.Should().NotBeNull();
-        method1!.Value.oVft.Should().Be(56);
-        method1!.Value.memid.Should().Be((int)Constants.BASE_OLEAUT_DISPID);
+        Assert.NotNull(method1);
+        Assert.Equal(56, method1!.Value.oVft);
+        Assert.Equal((int)Constants.BASE_OLEAUT_DISPID, method1!.Value.memid);
 
         using var method2 = testInterface!.GetFuncDescByName("Property2");
-        method2.Should().BeNull();
+        Assert.Null(method2);
 
         using var method3 = testInterface!.GetFuncDescByName("Property3", INVOKEKIND.INVOKE_PROPERTYGET);
-        method3.Should().NotBeNull();
-        method3!.Value.oVft.Should().Be(88);
-        method3!.Value.memid.Should().Be(((int)Constants.BASE_OLEAUT_DISPID) + 4);
+        Assert.NotNull(method3);
+        Assert.Equal(88, method3!.Value.oVft);
+        Assert.Equal(((int)Constants.BASE_OLEAUT_DISPID) + 4, method3!.Value.memid);
     }
 
     [Theory]
@@ -607,8 +600,8 @@ public class MemIdTest : BaseTest
         for (var i = 0; i < 500; i++)
         {
             var testMethod = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName($"TestMethod{dispIdStart + i}");
-            testMethod.Should().NotBeNull();
-            testMethod!.Value.memid.Should().Be(dispIdStart + i);
+            Assert.NotNull(testMethod);
+            Assert.Equal(dispIdStart + i, testMethod!.Value.memid);
         }
 
         using var property1 = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("Property1");
@@ -650,7 +643,7 @@ public class MemIdTest : BaseTest
         for (var i = 0; i < 100; i += 2)
         {
             var testMethod = result!.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName($"TestMethod{dispIdStart + i}");
-            testMethod.Should().NotBeNull();
+            Assert.NotNull(testMethod);
 
             // tlbexp.exe will ignore the MemId for the method with a wrong MarshalAsAttribute in case of a IUnkownInterface.
             // This behavior is a little bit strange. 
@@ -659,7 +652,7 @@ public class MemIdTest : BaseTest
             //  if (interfaceType == ComInterfaceType.InterfaceIsIUnknown)
             //              testMethod!.Value.memid.Should().Be(dispIdStart + (i / 2));
             //
-            testMethod!.Value.memid.Should().Be(dispIdStart + i);
+            Assert.Equal(dispIdStart + i, testMethod!.Value.memid);
         }
     }
 }

--- a/src/dscom.test/tests/MethodTests.cs
+++ b/src/dscom.test/tests/MethodTests.cs
@@ -15,6 +15,7 @@
 using System.Collections;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -32,12 +33,12 @@ public class MethodTest : BaseTest
                     .Build();
 
         using var releasableFuncDesc = result.TypeLib.GetTypeInfoByName("TestInterface")?.GetFuncDescByName("GetEnumerator");
-        releasableFuncDesc.Should().NotBeNull();
-        releasableFuncDesc!.Value.invkind.Should().Be(INVOKEKIND.INVOKE_FUNC);
-        releasableFuncDesc!.Value.memid.Should().Be(-4);
+        Assert.NotNull(releasableFuncDesc);
+        Assert.Equal(INVOKEKIND.INVOKE_FUNC, releasableFuncDesc!.Value.invkind);
+        Assert.Equal(-4, releasableFuncDesc!.Value.memid);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -57,13 +58,13 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         // Search for method
-        typeInfo!.ContainsFuncDescByName("TestMethod").Should().Be(true);
+        Assert.True(typeInfo!.ContainsFuncDescByName("TestMethod"));
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -89,17 +90,17 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         // Get and check TestMethod
         using var funcDesc = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDesc.Should().NotBeNull();
+        Assert.NotNull(funcDesc);
 
         // Check if return type if void
-        funcDesc!.Value.elemdescFunc.tdesc.vt.Should().Be((short)VarEnum.VT_VOID);
+        Assert.Equal((short)VarEnum.VT_VOID, funcDesc!.Value.elemdescFunc.tdesc.vt);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
 
     }
 
@@ -139,30 +140,30 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
         // Check number of parameters
-        funcDesc.cParams.Should().Be(1);
+        Assert.Equal(1, funcDesc.cParams);
 
         // Get first parameter
         var parameter = funcDesc.GetParameter(0);
-        parameter.Should().NotBeNull();
+        Assert.NotNull(parameter);
 
         // type should be Ptr
         var ptr = parameter!.Value.tdesc;
-        ptr.vt.Should().Be((short)VarEnum.VT_PTR);
+        Assert.Equal((short)VarEnum.VT_PTR, ptr.vt);
 
         // Ptr type should be the final typ
         var value = Marshal.PtrToStructure<TYPEDESC>(ptr.lpValue);
-        value.GetVarEnum().Should().Be(returnType.GetVarEnum());
+        Assert.Equal(returnType.GetVarEnum(), value.GetVarEnum());
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -201,17 +202,17 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
-        funcDesc.elemdescFunc.tdesc.vt.Should().Be(returnType.GetShortVarEnum());
+        Assert.Equal(returnType.GetShortVarEnum(), funcDesc.elemdescFunc.tdesc.vt);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -251,18 +252,18 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         typeInfo!.GetFuncDesc(7, out var ppFuncDesc);
-        ppFuncDesc.Should().NotBe(IntPtr.Zero);
+        Assert.NotEqual(IntPtr.Zero, ppFuncDesc);
 
         var funcDesc = Marshal.PtrToStructure<FUNCDESC>(ppFuncDesc);
-        funcDesc.elemdescFunc.tdesc.vt.Should().Be(returnType.GetShortVarEnum());
-        funcDesc.cParams.Should().Be(0);
+        Assert.Equal(returnType.GetShortVarEnum(), funcDesc.elemdescFunc.tdesc.vt);
+        Assert.Equal(0, funcDesc.cParams);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -278,19 +279,19 @@ public class MethodTest : BaseTest
                     .Build();
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
         typeInfo!.GetDocumentation(funcDesc.memid, out var methodString, out var docString, out var helpContext, out var helpFile);
-        docString.Should().NotBeNull();
-        docString.Should().BeEquivalentTo("Description");
+        Assert.NotNull(docString);
+        Assert.Equal("Description", docString);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -321,26 +322,25 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDesc = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDesc.Should().NotBeNull();
-        funcDesc!.Value.lprgelemdescParam.Should().NotBeNull();
+        Assert.NotNull(funcDesc);
 
         var firstParam = Marshal.PtrToStructure<ELEMDESC>(funcDesc.Value.lprgelemdescParam);
-        firstParam.tdesc.vt.Should().Be(parameterType.GetShortVarEnum());
+        Assert.Equal(parameterType.GetShortVarEnum(), firstParam.tdesc.vt);
         if (value != null)
         {
-            firstParam.desc.paramdesc.lpVarValue.Should().NotBe(IntPtr.Zero);
+            Assert.NotEqual(IntPtr.Zero, firstParam.desc.paramdesc.lpVarValue);
             var defaultValue = Marshal.GetObjectForNativeVariant(firstParam.desc.paramdesc.lpVarValue + 8);
-            defaultValue.Should().NotBeNull();
-            defaultValue!.GetType().Should().Be(acceptedReturnType);
-            defaultValue!.Should().Be(Convert.ChangeType(value, acceptedReturnType, CultureInfo.InvariantCulture));
+            Assert.NotNull(defaultValue);
+            Assert.Equal(acceptedReturnType, defaultValue!.GetType());
+            Assert.Equal(Convert.ChangeType(value, acceptedReturnType, CultureInfo.InvariantCulture), defaultValue);
         }
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -362,29 +362,26 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDesc = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDesc.Should().NotBeNull();
+        Assert.NotNull(funcDesc);
 
-        funcDesc!.Value.elemdescFunc.tdesc.vt.Should().Be(createdEnumType!.GetShortVarEnum());
-        funcDesc!.Value.elemdescFunc.tdesc.lpValue.Should().NotBeNull();
-        funcDesc!.Value.cParams.Should().Be(0);
+        Assert.Equal(createdEnumType!.GetShortVarEnum(), funcDesc!.Value.elemdescFunc.tdesc.vt);
+        Assert.Equal(0, funcDesc!.Value.cParams);
 
         ((ITypeInfo64Bit)typeInfo!).GetRefTypeInfo(funcDesc!.Value.elemdescFunc.tdesc.lpValue, out var typeInfoEnum);
-        typeInfoEnum.Should().NotBeNull();
+        Assert.NotNull(typeInfoEnum);
         typeInfoEnum.GetDocumentation(-1, out var strName, out var strDocString, out var dwHelpContext, out var strHelpFile);
-        strName.Should().NotBeNull();
-        strName.Should().BeEquivalentTo("TestEnum");
+        Assert.NotNull(strName);
+        Assert.Equal("TestEnum", strName);
         typeInfoEnum.GetTypeAttr(out var ppTypeAttr);
-        ppTypeAttr.Should().NotBeNull();
         var typeAttr = Marshal.PtrToStructure<TYPEATTR>(ppTypeAttr);
-        typeAttr.Should().NotBeNull();
-        typeAttr.typekind.Should().Be(TYPEKIND.TKIND_ENUM);
+        Assert.Equal(TYPEKIND.TKIND_ENUM, typeAttr.typekind);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -407,33 +404,28 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDesc = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDesc.Should().NotBeNull();
+        Assert.NotNull(funcDesc);
 
-        funcDesc!.Value.Should().NotBeNull();
-        funcDesc!.Value.cParams.Should().Be(1);
-        funcDesc!.Value.lprgelemdescParam.Should().NotBeNull();
+        Assert.Equal(1, funcDesc!.Value.cParams);
         var parameter = Marshal.PtrToStructure<ELEMDESC>(funcDesc!.Value.lprgelemdescParam);
 
-        parameter.tdesc.vt.Should().Be(createdEnumType!.GetShortVarEnum());
-        parameter.tdesc.lpValue.Should().NotBeNull();
+        Assert.Equal(createdEnumType!.GetShortVarEnum(), parameter.tdesc.vt);
 
         ((ITypeInfo64Bit)typeInfo!).GetRefTypeInfo(parameter.tdesc.lpValue, out var typeInfoEnum);
-        typeInfoEnum.Should().NotBeNull();
+        Assert.NotNull(typeInfoEnum);
         typeInfoEnum.GetDocumentation(-1, out var strName, out var strDocString, out var dwHelpContext, out var strHelpFile);
-        strName.Should().NotBeNull();
-        strName.Should().BeEquivalentTo("TestEnum");
+        Assert.NotNull(strName);
+        Assert.Equal("TestEnum", strName);
         typeInfoEnum.GetTypeAttr(out var ppTypeAttr);
-        ppTypeAttr.Should().NotBeNull();
         var typeAttr = Marshal.PtrToStructure<TYPEATTR>(ppTypeAttr);
-        typeAttr.Should().NotBeNull();
-        typeAttr.typekind.Should().Be(TYPEKIND.TKIND_ENUM);
+        Assert.Equal(TYPEKIND.TKIND_ENUM, typeAttr.typekind);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -452,31 +444,28 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //Check mathod
         using var funcDesc = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDesc.Should().NotBeNull();
+        Assert.NotNull(funcDesc);
 
-        funcDesc!.Value.elemdescFunc.tdesc.vt.Should().Be(createdInterfaceType!.GetShortVarEnum());
-        funcDesc!.Value.elemdescFunc.tdesc.lpValue.Should().NotBeNull();
-        funcDesc!.Value.cParams.Should().Be(0);
+        Assert.Equal(createdInterfaceType!.GetShortVarEnum(), funcDesc!.Value.elemdescFunc.tdesc.vt);
+        Assert.Equal(0, funcDesc!.Value.cParams);
 
         var typeDesc = Marshal.PtrToStructure<TYPEDESC>(funcDesc!.Value.elemdescFunc.tdesc.lpValue);
-        typeDesc.vt.Should().Be((short)VarEnum.VT_USERDEFINED);
+        Assert.Equal((short)VarEnum.VT_USERDEFINED, typeDesc.vt);
         ((ITypeInfo64Bit)typeInfo!).GetRefTypeInfo(typeDesc.lpValue, out var typeInfoEnum);
-        typeInfoEnum.Should().NotBeNull();
+        Assert.NotNull(typeInfoEnum);
         typeInfoEnum.GetDocumentation(-1, out var strName, out var strDocString, out var dwHelpContext, out var strHelpFile);
-        strName.Should().NotBeNull();
-        strName.Should().BeEquivalentTo("ReferencedInterface");
+        Assert.NotNull(strName);
+        Assert.Equal("ReferencedInterface", strName);
         typeInfoEnum.GetTypeAttr(out var ppTypeAttr);
-        ppTypeAttr.Should().NotBeNull();
         var typeAttr = Marshal.PtrToStructure<TYPEATTR>(ppTypeAttr);
-        typeAttr.Should().NotBeNull();
-        typeAttr.typekind.Should().Be(TYPEKIND.TKIND_DISPATCH);
+        Assert.Equal(TYPEKIND.TKIND_DISPATCH, typeAttr.typekind);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -496,36 +485,31 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var releasableFuncDesc = typeInfo!.GetFuncDescByName("TestMethod");
-        releasableFuncDesc.Should().NotBeNull();
+        Assert.NotNull(releasableFuncDesc);
         var funcDesc = releasableFuncDesc!.Value;
 
-        funcDesc.Should().NotBeNull();
-        funcDesc.cParams.Should().Be(1);
-        funcDesc.lprgelemdescParam.Should().NotBeNull();
+        Assert.Equal(1, funcDesc.cParams);
         var parameter = Marshal.PtrToStructure<ELEMDESC>(funcDesc.lprgelemdescParam);
 
-        parameter.tdesc.vt.Should().Be(createdInterfaceType!.GetShortVarEnum());
-        parameter.tdesc.lpValue.Should().NotBeNull();
+        Assert.Equal(createdInterfaceType!.GetShortVarEnum(), parameter.tdesc.vt);
 
         var typeDesc = Marshal.PtrToStructure<TYPEDESC>(parameter.tdesc.lpValue);
-        typeDesc.vt.Should().Be((short)VarEnum.VT_USERDEFINED);
+        Assert.Equal((short)VarEnum.VT_USERDEFINED, typeDesc.vt);
         ((ITypeInfo64Bit)typeInfo!).GetRefTypeInfo(typeDesc.lpValue, out var typeInfoEnum);
-        typeInfoEnum.Should().NotBeNull();
+        Assert.NotNull(typeInfoEnum);
         typeInfoEnum.GetDocumentation(-1, out var strName, out var strDocString, out var dwHelpContext, out var strHelpFile);
-        strName.Should().NotBeNull();
-        strName.Should().BeEquivalentTo("ReferencedInterface");
+        Assert.NotNull(strName);
+        Assert.Equal("ReferencedInterface", strName);
         typeInfoEnum.GetTypeAttr(out var ppTypeAttr);
-        ppTypeAttr.Should().NotBeNull();
         var typeAttr = Marshal.PtrToStructure<TYPEATTR>(ppTypeAttr);
-        typeAttr.Should().NotBeNull();
-        typeAttr.typekind.Should().Be(TYPEKIND.TKIND_DISPATCH);
+        Assert.Equal(TYPEKIND.TKIND_DISPATCH, typeAttr.typekind);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -543,22 +527,21 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
-        funcDesc.elemdescFunc.tdesc.vt.Should().Be(typeof(string[]).GetShortVarEnum());
-        funcDesc.elemdescFunc.tdesc.lpValue.Should().NotBeNull();
-        funcDesc.cParams.Should().Be(0);
+        Assert.Equal(typeof(string[]).GetShortVarEnum(), funcDesc.elemdescFunc.tdesc.vt);
+        Assert.Equal(0, funcDesc.cParams);
 
         var typeDesc = Marshal.PtrToStructure<TYPEDESC>(funcDesc.elemdescFunc.tdesc.lpValue);
-        typeDesc.vt.Should().Be(typeof(string).GetShortVarEnum());
+        Assert.Equal(typeof(string).GetShortVarEnum(), typeDesc.vt);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -577,26 +560,23 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
-        funcDesc.Should().NotBeNull();
-        funcDesc.cParams.Should().Be(1);
-        funcDesc.lprgelemdescParam.Should().NotBeNull();
+        Assert.Equal(1, funcDesc.cParams);
         var parameter = Marshal.PtrToStructure<ELEMDESC>(funcDesc.lprgelemdescParam);
 
-        parameter.tdesc!.GetVarEnum().Should().Be(typeof(string[]).GetVarEnum());
-        parameter.tdesc.lpValue.Should().NotBeNull();
+        Assert.Equal(typeof(string[]).GetVarEnum(), parameter.tdesc!.GetVarEnum());
 
         var typeDesc = Marshal.PtrToStructure<TYPEDESC>(parameter.tdesc.lpValue);
-        typeDesc.GetVarEnum().Should().Be(typeof(string).GetVarEnum());
+        Assert.Equal(typeof(string).GetVarEnum(), typeDesc.GetVarEnum());
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -618,16 +598,16 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         // Check method
         using var funcDesc = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDesc.Should().NotBeNull();
+        Assert.NotNull(funcDesc);
 
-        funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum().Should().Be(VarEnum.VT_UNKNOWN);
+        Assert.Equal(VarEnum.VT_UNKNOWN, funcDesc!.Value.elemdescFunc.tdesc.GetVarEnum());
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -654,16 +634,16 @@ public class MethodTest : BaseTest
                     .Build();
 
         using var method1 = result.TypeLib.GetTypeInfoByName("TestInterface")?.GetFuncDescByName("TestMethod");
-        method1.Should().NotBeNull();
+        Assert.NotNull(method1);
 
         using var method2 = result.TypeLib.GetTypeInfoByName("TestInterface")?.GetFuncDescByName("TestMethod_2");
-        method1.Should().NotBeNull();
+        Assert.NotNull(method2);
 
         using var method3 = result.TypeLib.GetTypeInfoByName("TestInterface")?.GetFuncDescByName("TestMethod_3");
-        method1.Should().NotBeNull();
+        Assert.NotNull(method3);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -685,16 +665,16 @@ public class MethodTest : BaseTest
                     .Build();
 
         using var function = result.TypeLib.GetTypeInfoByName("TestInterface")!.GetFuncDescByName("TestMethod");
-        function.Should().NotBeNull();
+        Assert.NotNull(function);
 
         var parameter = function!.Value.GetParameter(0);
-        parameter.Should().NotBeNull("Parameter should be present");
+        Assert.NotNull(parameter);
 
-        parameter!.Value.desc.paramdesc.wParamFlags.Should().Be(PARAMFLAG.PARAMFLAG_FOUT | PARAMFLAG.PARAMFLAG_FIN);
-        parameter!.Value.tdesc.GetVarEnum().Should().Be(VarEnum.VT_PTR);
+        Assert.Equal(PARAMFLAG.PARAMFLAG_FOUT | PARAMFLAG.PARAMFLAG_FIN, parameter!.Value.desc.paramdesc.wParamFlags);
+        Assert.Equal(VarEnum.VT_PTR, parameter!.Value.tdesc.GetVarEnum());
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -715,35 +695,32 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
-        funcDesc.Should().NotBeNull();
-        funcDesc.cParams.Should().Be(1);
-        funcDesc.lprgelemdescParam.Should().NotBeNull();
+        Assert.Equal(1, funcDesc.cParams);
         var parameter = Marshal.PtrToStructure<ELEMDESC>(funcDesc.lprgelemdescParam);
 
-        parameter.tdesc.vt.Should().Be((short)VarEnum.VT_SAFEARRAY);
-        parameter.tdesc.lpValue.Should().NotBeNull();
+        Assert.Equal((short)VarEnum.VT_SAFEARRAY, parameter.tdesc.vt);
 
         var typeDesc = Marshal.PtrToStructure<TYPEDESC>(parameter.tdesc.lpValue);
-        typeDesc.GetVarEnum().Should().Be(VarEnum.VT_PTR);
+        Assert.Equal((short)VarEnum.VT_PTR, typeDesc.vt);
 
         var typeDescUserDefined = Marshal.PtrToStructure<TYPEDESC>(typeDesc.lpValue);
-        typeDescUserDefined.vt.Should().Be((short)VarEnum.VT_USERDEFINED);
+        Assert.Equal((short)VarEnum.VT_USERDEFINED, typeDescUserDefined.vt);
 
         var typeInfo64Bit = (ITypeInfo64Bit)typeInfo!;
         typeInfo64Bit.GetRefTypeInfo(typeDescUserDefined.lpValue, out var refTypeInfo64Bit);
         refTypeInfo64Bit.GetDocumentation(-1, out var typeInfoName, out var docString, out var helpContext, out var helpFile);
 
-        typeInfoName.Should().Be("TestInterfaceUsedInParameter");
+        Assert.Equal("TestInterfaceUsedInParameter", typeInfoName);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
 
@@ -764,37 +741,35 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
-        funcDesc.Should().NotBeNull();
-        funcDesc.cParams.Should().Be(1);
-        funcDesc.lprgelemdescParam.Should().NotBeNull();
+        Assert.Equal(1, funcDesc.cParams);
         var parameter = Marshal.PtrToStructure<ELEMDESC>(funcDesc.lprgelemdescParam);
 
-        parameter.tdesc.GetVarEnum().Should().Be(VarEnum.VT_PTR);
+        Assert.Equal(VarEnum.VT_PTR, parameter.tdesc.GetVarEnum());
 
         var typeDesc = Marshal.PtrToStructure<TYPEDESC>(parameter.tdesc.lpValue);
-        typeDesc.GetVarEnum().Should().Be(VarEnum.VT_SAFEARRAY);
+        Assert.Equal(VarEnum.VT_SAFEARRAY, typeDesc.GetVarEnum());
 
         var typeDesc2 = Marshal.PtrToStructure<TYPEDESC>(typeDesc.lpValue);
-        typeDesc2.GetVarEnum().Should().Be(VarEnum.VT_PTR);
+        Assert.Equal(VarEnum.VT_PTR, typeDesc2.GetVarEnum());
 
         var typeDesc3 = Marshal.PtrToStructure<TYPEDESC>(typeDesc2.lpValue);
-        typeDesc3.GetVarEnum().Should().Be(VarEnum.VT_USERDEFINED);
+        Assert.Equal(VarEnum.VT_USERDEFINED, typeDesc3.GetVarEnum());
 
         var typeInfo64Bit = (ITypeInfo64Bit)typeInfo!;
         typeInfo64Bit.GetRefTypeInfo(typeDesc3.lpValue, out var refTypeInfo64Bit);
         refTypeInfo64Bit.GetDocumentation(-1, out var typeInfoName, out var docString, out var helpContext, out var helpFile);
 
-        typeInfoName.Should().Be("TestInterfaceReturnValue");
+        Assert.Equal("TestInterfaceReturnValue", typeInfoName);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -814,35 +789,32 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
-        funcDesc.Should().NotBeNull();
-        funcDesc.cParams.Should().Be(1);
-        funcDesc.lprgelemdescParam.Should().NotBeNull();
+        Assert.Equal(1, funcDesc.cParams);
         var parameter = Marshal.PtrToStructure<ELEMDESC>(funcDesc.lprgelemdescParam);
 
-        ((VarEnum)parameter.tdesc.vt).Should().Be(VarEnum.VT_SAFEARRAY);
-        parameter.tdesc.lpValue.Should().NotBeNull();
+        Assert.Equal(VarEnum.VT_SAFEARRAY, (VarEnum)parameter.tdesc.vt);
 
         var typeDesc = Marshal.PtrToStructure<TYPEDESC>(parameter.tdesc.lpValue);
-        ((VarEnum)typeDesc.vt).Should().Be(VarEnum.VT_PTR);
+        Assert.Equal(VarEnum.VT_PTR, (VarEnum)typeDesc.vt);
 
         var typeDescUserDefined = Marshal.PtrToStructure<TYPEDESC>(typeDesc.lpValue);
-        ((VarEnum)typeDescUserDefined.vt).Should().Be(VarEnum.VT_USERDEFINED);
+        Assert.Equal(VarEnum.VT_USERDEFINED, (VarEnum)typeDescUserDefined.vt);
 
         var typeInfo64Bit = (ITypeInfo64Bit)typeInfo!;
         typeInfo64Bit.GetRefTypeInfo(typeDescUserDefined.lpValue, out var refTypeInfo64Bit);
         refTypeInfo64Bit.GetDocumentation(-1, out var typeInfoName, out var docString, out var helpContext, out var helpFile);
 
-        typeInfoName.Should().Be("TestInterfaceUsedInParameter");
+        Assert.Equal("TestInterfaceUsedInParameter", typeInfoName);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -865,22 +837,21 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
 
         // Get first parameter
-        funcDescByName!.Value.cParams.Should().Be(1);
-        funcDescByName!.Value.lprgelemdescParam.Should().NotBeNull();
+        Assert.Equal(1, funcDescByName!.Value.cParams);
         var parameter = Marshal.PtrToStructure<ELEMDESC>(funcDescByName!.Value.lprgelemdescParam);
 
         //First parameter should be VT_UNKNOWN
-        parameter.tdesc.GetVarEnum().Should().Be(VarEnum.VT_UNKNOWN);
+        Assert.Equal(VarEnum.VT_UNKNOWN, parameter.tdesc.GetVarEnum());
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().ContainSingle(x => x.EventKind == ExporterEventKind.NOTIF_CONVERTWARNING);
+        Assert.Single(result.TypeLibExporterNotifySink.ReportedEvents, x => x.EventKind == ExporterEventKind.NOTIF_CONVERTWARNING);
     }
 
     [Fact]
@@ -900,24 +871,23 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("ReturnInvisibleInterface");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
-        funcDesc.Should().NotBeNull();
-        funcDesc.cParams.Should().Be(1);
-        funcDesc.lprgelemdescParam.Should().NotBeNull();
+        Assert.Equal(1, funcDesc.cParams);
         var parameter = Marshal.PtrToStructure<ELEMDESC>(funcDesc.lprgelemdescParam);
 
-        parameter.tdesc.GetVarEnum().Should().Be(VarEnum.VT_PTR);
+        Assert.Equal(VarEnum.VT_PTR, parameter.tdesc.GetVarEnum());
         var childTypeDesc = Marshal.PtrToStructure<TYPEDESC>(parameter.tdesc.lpValue);
-        childTypeDesc.GetVarEnum().Should().Be(VarEnum.VT_UNKNOWN);
+
+        Assert.Equal(VarEnum.VT_UNKNOWN, childTypeDesc.GetVarEnum());
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().ContainSingle(x => x.EventKind == ExporterEventKind.NOTIF_CONVERTWARNING);
+        Assert.Single(result.TypeLibExporterNotifySink.ReportedEvents, x => x.EventKind == ExporterEventKind.NOTIF_CONVERTWARNING);
     }
 
     [Theory]
@@ -956,29 +926,29 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
         // Check number of parameters
-        funcDesc.cParams.Should().Be(1);
+        Assert.Equal(1, funcDesc.cParams);
 
         // Get first parameter
         var parameter = funcDesc.GetParameter(0);
-        parameter.Should().NotBeNull();
+        Assert.NotNull(parameter);
 
         // type should be Ptr
         var ptr = parameter!.Value.tdesc;
-        ptr.GetVarEnum().Should().Be(parameterType.GetVarEnum());
+        Assert.Equal(parameterType.GetVarEnum(), ptr.GetVarEnum());
 
-        parameter!.Value.desc.idldesc.wIDLFlags.Should().Be(IDLFLAG.IDLFLAG_FOUT);
-        parameter!.Value.desc.paramdesc.wParamFlags.Should().Be(PARAMFLAG.PARAMFLAG_FOUT);
+        Assert.Equal(IDLFLAG.IDLFLAG_FOUT, parameter!.Value.desc.idldesc.wIDLFlags);
+        Assert.Equal(PARAMFLAG.PARAMFLAG_FOUT, parameter!.Value.desc.paramdesc.wParamFlags);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -1017,29 +987,29 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
         // Check number of parameters
-        funcDesc.cParams.Should().Be(1);
+        Assert.Equal(1, funcDesc.cParams);
 
         // Get first parameter
         var parameter = funcDesc.GetParameter(0);
-        parameter.Should().NotBeNull();
+        Assert.NotNull(parameter);
 
         // type should be Ptr
         var ptr = parameter!.Value.tdesc;
-        ptr.GetVarEnum().Should().Be(parameterType.GetVarEnum());
+        Assert.Equal(parameterType.GetVarEnum(), ptr.GetVarEnum());
 
-        parameter!.Value.desc.idldesc.wIDLFlags.Should().Be(IDLFLAG.IDLFLAG_FOUT);
-        parameter!.Value.desc.paramdesc.wParamFlags.Should().Be(PARAMFLAG.PARAMFLAG_FOUT);
+        Assert.Equal(IDLFLAG.IDLFLAG_FOUT, parameter!.Value.desc.idldesc.wIDLFlags);
+        Assert.Equal(PARAMFLAG.PARAMFLAG_FOUT, parameter!.Value.desc.paramdesc.wParamFlags);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -1078,29 +1048,29 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
         // Check number of parameters
-        funcDesc.cParams.Should().Be(1);
+        Assert.Equal(1, funcDesc.cParams);
 
         // Get first parameter
         var parameter = funcDesc.GetParameter(0);
-        parameter.Should().NotBeNull();
+        Assert.NotNull(parameter);
 
         // type should be Ptr
         var ptr = parameter!.Value.tdesc;
-        ptr.GetVarEnum().Should().Be(parameterType.GetVarEnum());
+        Assert.Equal(parameterType.GetVarEnum(), ptr.GetVarEnum());
 
-        parameter!.Value.desc.idldesc.wIDLFlags.Should().Be(IDLFLAG.IDLFLAG_FOUT);
-        parameter!.Value.desc.paramdesc.wParamFlags.Should().Be(PARAMFLAG.PARAMFLAG_FOUT);
+        Assert.Equal(IDLFLAG.IDLFLAG_FOUT, parameter!.Value.desc.idldesc.wIDLFlags);
+        Assert.Equal(PARAMFLAG.PARAMFLAG_FOUT, parameter!.Value.desc.paramdesc.wParamFlags);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -1123,6 +1093,7 @@ public class MethodTest : BaseTest
     [InlineData(typeof(Guid))]
     [InlineData(typeof(System.Drawing.Color))]
     [InlineData(typeof(decimal))]
+    [InlineData(typeof(Delegate))]
     [InlineData(typeof(IntPtr))]
     public void InterfaceIsIUnknownWithMethodWithArrayOutParameter_OutParameterIsCorrect(Type parameterType)
     {
@@ -1137,22 +1108,22 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
         // Check number of parameters
-        funcDesc.cParams.Should().Be(1);
+        Assert.Equal(1, funcDesc.cParams);
 
         // Get first parameter
         var parameter = funcDesc.GetParameter(0);
-        parameter.Should().NotBeNull();
+        Assert.NotNull(parameter);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -1175,6 +1146,7 @@ public class MethodTest : BaseTest
     [InlineData(typeof(Guid))]
     [InlineData(typeof(System.Drawing.Color))]
     [InlineData(typeof(decimal))]
+    [InlineData(typeof(Delegate))]
     [InlineData(typeof(IntPtr))]
     public void InterfaceIsIDispatchWithMethodWithArrayOutParameter_OutParameterIsCorrect(Type parameterType)
     {
@@ -1189,22 +1161,22 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
         // Check number of parameters
-        funcDesc.cParams.Should().Be(1);
+        Assert.Equal(1, funcDesc.cParams);
 
         // Get first parameter
         var parameter = funcDesc.GetParameter(0);
-        parameter.Should().NotBeNull();
+        Assert.NotNull(parameter);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -1227,6 +1199,7 @@ public class MethodTest : BaseTest
     [InlineData(typeof(Guid))]
     [InlineData(typeof(System.Drawing.Color))]
     [InlineData(typeof(decimal))]
+    [InlineData(typeof(Delegate))]
     [InlineData(typeof(IntPtr))]
     public void InterfaceIsDualWithMethodWithArrayOutParameter_OutParameterIsCorrect(Type parameterType)
     {
@@ -1241,22 +1214,22 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
         // Check number of parameters
-        funcDesc.cParams.Should().Be(1);
+        Assert.Equal(1, funcDesc.cParams);
 
         // Get first parameter
         var parameter = funcDesc.GetParameter(0);
-        parameter.Should().NotBeNull();
+        Assert.NotNull(parameter);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -1279,22 +1252,22 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
         // Check number of parameters
-        funcDesc.cParams.Should().Be(1);
+        Assert.Equal(1, funcDesc.cParams);
 
         // Get first parameter
         var parameter = funcDesc.GetParameter(0);
-        parameter.Should().NotBeNull();
+        Assert.NotNull(parameter);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -1317,6 +1290,7 @@ public class MethodTest : BaseTest
     [InlineData(typeof(Guid))]
     [InlineData(typeof(System.Drawing.Color))]
     [InlineData(typeof(decimal))]
+    [InlineData(typeof(Delegate))]
     [InlineData(typeof(IntPtr))]
     public void InterfaceIsDualWithMethodWithRefParameter_RefParameterIsCorrect(Type parameterType)
     {
@@ -1331,33 +1305,33 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
         // Check number of parameters
-        funcDesc.cParams.Should().Be(1);
+        Assert.Equal(1, funcDesc.cParams);
 
         // Get first parameter
         var parameter = funcDesc.GetParameter(0);
-        parameter.Should().NotBeNull();
+        Assert.NotNull(parameter);
 
-        parameter!.Value.tdesc.GetVarEnum().Should().Be(VarEnum.VT_PTR);
+        Assert.Equal(VarEnum.VT_PTR, parameter!.Value.tdesc.GetVarEnum());
 
         var subtypeDesc = Marshal.PtrToStructure<TYPEDESC>(parameter!.Value.tdesc.lpValue);
-        subtypeDesc.GetVarEnum().Should().Be(parameterType.GetVarEnum());
+        Assert.Equal(parameterType.GetVarEnum(), subtypeDesc.GetVarEnum());
 
         if (parameterType.IsEnum || parameterType.IsInterface)
         {
             var subsubtypeDesc = Marshal.PtrToStructure<TYPEDESC>(subtypeDesc.lpValue);
-            subsubtypeDesc.GetVarEnum().Should().Be(VarEnum.VT_USERDEFINED);
+            Assert.Equal(VarEnum.VT_USERDEFINED, subsubtypeDesc.GetVarEnum());
         }
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -1378,12 +1352,12 @@ public class MethodTest : BaseTest
                     .Build();
 
         var type = result.TypeLib.GetTypeInfoByName("TestInterface");
-        type.Should().NotBeNull();
+        Assert.NotNull(type);
 
-        type!.GetFuncDescByName("TestMethod").Should().NotBeNull();
+        Assert.NotNull(type!.GetFuncDescByName("TestMethod"));
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Fact]
@@ -1398,14 +1372,14 @@ public class MethodTest : BaseTest
                     .Build();
 
         var type = result.TypeLib.GetTypeInfoByName("TestInterface");
-        type.Should().NotBeNull();
+        Assert.NotNull(type);
 
-        type!.GetFuncDescByName("AddRef").Should().NotBeNull();
-        type!.GetFuncDescByName("AddRef_2").Should().NotBeNull();
-        type!.GetFuncDescByName("AddRef_3").Should().BeNull();
+        Assert.NotNull(type!.GetFuncDescByName("AddRef"));
+        Assert.NotNull(type!.GetFuncDescByName("AddRef_2"));
+        Assert.Null(type!.GetFuncDescByName("AddRef_3"));
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -1437,25 +1411,24 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDesc = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDesc.Should().NotBeNull();
-        funcDesc!.Value.lprgelemdescParam.Should().NotBeNull();
+        Assert.NotNull(funcDesc);
 
         // Get first parameter
         var parameter = funcDesc!.Value.GetParameter(0);
-        parameter.Should().NotBeNull();
+        Assert.NotNull(parameter);
 
         // Check type
         var typeDesc = parameter!.Value.tdesc;
-        typeDesc.GetVarEnum().Should().Be(parameterType.GetVarEnum());
+        Assert.Equal(parameterType.GetVarEnum(), typeDesc.GetVarEnum());
 
-        parameter!.Value.desc.paramdesc.wParamFlags.Should().Be(PARAMFLAG.PARAMFLAG_FIN | PARAMFLAG.PARAMFLAG_FHASDEFAULT);
+        Assert.Equal(PARAMFLAG.PARAMFLAG_FIN | PARAMFLAG.PARAMFLAG_FHASDEFAULT, parameter!.Value.desc.paramdesc.wParamFlags);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -1491,23 +1464,23 @@ public class MethodTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestMethod");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
         // Check number of parameters
-        funcDesc.cParams.Should().Be(1);
+        Assert.Equal(1, funcDesc.cParams);
 
         // Get first parameter
         var parameter = funcDesc.GetParameter(0);
-        parameter.Should().NotBeNull();
+        Assert.NotNull(parameter);
 
-        parameter!.Value.desc.idldesc.wIDLFlags.Should().Be(IDLFLAG.IDLFLAG_FIN);
+        Assert.Equal(IDLFLAG.IDLFLAG_FIN, parameter!.Value.desc.idldesc.wIDLFlags);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 }

--- a/src/dscom.test/tests/NamesTest.cs
+++ b/src/dscom.test/tests/NamesTest.cs
@@ -14,6 +14,7 @@
 
 using System.Runtime.InteropServices;
 using dSPACE.Runtime.InteropServices.Attributes;
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -36,18 +37,18 @@ public class NamesTest : BaseTest
             .Build();
 
         var typeLibInfo = result.TypeLib.GetTypeInfoByName("touppercase");
-        typeLibInfo.Should().BeNull();
+        Assert.Null(typeLibInfo);
         typeLibInfo = result.TypeLib.GetTypeInfoByName("TOUPPERCASE");
-        typeLibInfo.Should().NotBeNull();
+        Assert.NotNull(typeLibInfo);
         var kv = typeLibInfo!.GetAllEnumValues();
-        kv.Should().OnlyContain(z => z.Key.StartsWith("TOUPPERCASE"));
+        Assert.All(kv, z => Assert.StartsWith("TOUPPERCASE", z.Key));
 
         typeLibInfo = result.TypeLib.GetTypeInfoByName("TOLOWERCASE");
-        typeLibInfo.Should().BeNull();
+        Assert.Null(typeLibInfo);
         typeLibInfo = result.TypeLib.GetTypeInfoByName("tolowercase");
-        typeLibInfo.Should().NotBeNull();
+        Assert.NotNull(typeLibInfo);
         kv = typeLibInfo!.GetAllEnumValues();
-        kv.Should().OnlyContain(z => z.Key.StartsWith("tolowercase"));
+        Assert.All(kv, z => Assert.StartsWith("tolowercase", z.Key));
     }
 
     [Fact]
@@ -64,11 +65,11 @@ public class NamesTest : BaseTest
             .Build(useComAlias: true);
 
         var typeLibInfo = result.TypeLib.GetTypeInfoByName("touppercase");
-        typeLibInfo.Should().BeNull();
+        Assert.Null(typeLibInfo);
         typeLibInfo = result.TypeLib.GetTypeInfoByName("froofroo");
-        typeLibInfo.Should().NotBeNull();
+        Assert.NotNull(typeLibInfo);
         var kv = typeLibInfo!.GetAllEnumValues();
-        kv.Should().OnlyContain(z => z.Key.StartsWith("froofroo"));
+        Assert.All(kv, z => Assert.StartsWith("froofroo", z.Key));
     }
 
     [Fact]
@@ -85,11 +86,11 @@ public class NamesTest : BaseTest
             .Build(useComAlias: true);
 
         var typeLibInfo = result.TypeLib.GetTypeInfoByName("touppercase");
-        typeLibInfo.Should().BeNull();
+        Assert.Null(typeLibInfo);
         typeLibInfo = result.TypeLib.GetTypeInfoByName("froofroo");
-        typeLibInfo.Should().NotBeNull();
+        Assert.NotNull(typeLibInfo);
         var kv = typeLibInfo!.GetAllEnumValues();
-        kv.Should().OnlyContain(z => z.Key == "fizz" || z.Key == "buzz" || z.Key == "fizzbuzz");
+        Assert.All(kv, z => Assert.Contains(z.Key, new[] { "fizz", "buzz", "fizzbuzz" }));
     }
 
     [Fact]
@@ -112,26 +113,25 @@ public class NamesTest : BaseTest
             .Build(useComAlias: true);
 
         var typeLibInfo = result.TypeLib.GetTypeInfoByName("_enumAlias");
-        typeLibInfo.Should().NotBeNull();
+        Assert.NotNull(typeLibInfo);
 
         var funcDescValue = typeLibInfo!.GetFuncDescByName("getFruit");
-        funcDescValue!.Value.Should().NotBeNull();
+        Assert.NotNull(funcDescValue);
         var funcDesc = funcDescValue.Value;
 
         var elemDescParam = funcDesc.GetParameter(0)!.Value;
         var paramDesc = elemDescParam.desc.paramdesc;
-        paramDesc.Should().NotBeNull();
 
         // the lpVarValue points to a PARAMDESCEX, but we don't care about the size, so dereference the VARIANTARG
         // structure directly at the offset'd address.
         var varValue = Marshal.GetObjectForNativeVariant(paramDesc.lpVarValue + sizeof(ulong));
-        varValue.Should().Be(20);
+        Assert.Equal(20, varValue);
 
         typeLibInfo!.GetRefTypeInfo(funcDesc.elemdescFunc.tdesc.lpValue.ExtractInt32(), out var returnType);
-        returnType.GetName().Should().Be("froofroo");
+        Assert.Equal("froofroo", returnType.GetName());
 
         typeLibInfo.GetRefTypeInfo(elemDescParam.tdesc.lpValue.ExtractInt32(), out var paramType);
-        paramType.GetName().Should().Be("froofroo");
+        Assert.Equal("froofroo", paramType.GetName());
     }
 
     [Fact]
@@ -147,11 +147,11 @@ public class NamesTest : BaseTest
             .Build(useComAlias: true);
 
         var typeLibInfo = result.TypeLib.GetTypeInfoByName("TOUPPERCASE");
-        typeLibInfo.Should().BeNull();
+        Assert.Null(typeLibInfo);
         typeLibInfo = result.TypeLib.GetTypeInfoByName("touppercase");
-        typeLibInfo.Should().NotBeNull();
+        Assert.NotNull(typeLibInfo);
         var kv = typeLibInfo!.GetAllEnumValues();
-        kv.Should().OnlyContain(z => z.Key == "fizz" || z.Key == "buzz" || z.Key == "fizzbuzz");
+        Assert.All(kv, z => Assert.Contains(z.Key, new[] { "fizz", "buzz", "fizzbuzz" }));
     }
 
     [Fact]
@@ -165,14 +165,14 @@ public class NamesTest : BaseTest
                         .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("touppercase");
-        typeInfo.Should().BeNull("touppercase found");
+        Assert.Null(typeInfo);
         typeInfo = result.TypeLib.GetTypeInfoByName("TOUPPERCASE");
-        typeInfo.Should().NotBeNull("TOUPPERCASE not found");
+        Assert.NotNull(typeInfo);
 
         typeInfo = result.TypeLib.GetTypeInfoByName("TOLOWERCASE");
-        typeInfo.Should().BeNull("TOLOWERCASE case found");
+        Assert.Null(typeInfo);
         typeInfo = result.TypeLib.GetTypeInfoByName("tolowercase");
-        typeInfo.Should().NotBeNull("tolowercase not found");
+        Assert.NotNull(typeInfo);
     }
 
     [Fact]
@@ -204,14 +204,14 @@ public class NamesTest : BaseTest
                     .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
-        typeInfo!.GetFuncDescByName("TestMethod").Should().NotBeNull("TestMethod should be available");
-        typeInfo!.GetFuncDescByName("TestMethod")!.Value.cParams.Should().Be(2);
-        typeInfo!.GetFuncDescByName("TestMethod_2").Should().NotBeNull("TestMethod_2 should be available");
-        typeInfo!.GetFuncDescByName("TestMethod_2")!.Value.cParams.Should().Be(4);
-        typeInfo!.GetFuncDescByName("TestMethod_3").Should().BeNull("TestMethod_3 should not be available");
-        typeInfo!.GetFuncDescByName("TestMethod_4").Should().BeNull("TestMethod_4 should not be available");
+        Assert.NotNull(typeInfo!.GetFuncDescByName("TestMethod"));
+        Assert.Equal(2, typeInfo!.GetFuncDescByName("TestMethod")!.Value.cParams);
+        Assert.NotNull(typeInfo!.GetFuncDescByName("TestMethod_2"));
+        Assert.Equal(4, typeInfo!.GetFuncDescByName("TestMethod_2")!.Value.cParams);
+        Assert.Null(typeInfo!.GetFuncDescByName("TestMethod_3"));
+        Assert.Null(typeInfo!.GetFuncDescByName("TestMethod_4"));
     }
 
     [Fact]
@@ -236,14 +236,14 @@ public class NamesTest : BaseTest
                     .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
-        typeInfo!.GetFuncDescByName("TestMethod").Should().NotBeNull("TestMethod should be available");
-        typeInfo!.GetFuncDescByName("TestMethod")!.Value.cParams.Should().Be(1);
-        typeInfo!.GetFuncDescByName("TestMethod_3").Should().NotBeNull("TestMethod should be available");
-        typeInfo!.GetFuncDescByName("TestMethod_3")!.Value.cParams.Should().Be(3);
+        Assert.NotNull(typeInfo!.GetFuncDescByName("TestMethod"));
+        Assert.Equal(1, typeInfo!.GetFuncDescByName("TestMethod")!.Value.cParams);
+        Assert.NotNull(typeInfo!.GetFuncDescByName("TestMethod_3"));
+        Assert.Equal(3, typeInfo!.GetFuncDescByName("TestMethod_3")!.Value.cParams);
 
-        typeInfo!.GetFuncDescByName("TestMethod_2").Should().BeNull("TestMethod should not be available");
+        Assert.Null(typeInfo!.GetFuncDescByName("TestMethod_2"));
     }
 
     [Fact]
@@ -266,13 +266,13 @@ public class NamesTest : BaseTest
                     .Build();
 
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull();
+        Assert.NotNull(typeInfo);
 
-        typeInfo!.GetFuncDescByName("TestMethod").Should().NotBeNull("TestMethod should be available");
-        typeInfo!.GetFuncDescByName("TestMethod")!.Value.cParams.Should().Be(1);
-        typeInfo!.GetFuncDescByName("TestMethod_3").Should().NotBeNull("TestMethod should be available");
-        typeInfo!.GetFuncDescByName("TestMethod_3")!.Value.cParams.Should().Be(3);
+        Assert.NotNull(typeInfo!.GetFuncDescByName("TestMethod"));
+        Assert.Equal(1, typeInfo!.GetFuncDescByName("TestMethod")!.Value.cParams);
+        Assert.NotNull(typeInfo!.GetFuncDescByName("TestMethod_3"));
+        Assert.Equal(3, typeInfo!.GetFuncDescByName("TestMethod_3")!.Value.cParams);
 
-        typeInfo!.GetFuncDescByName("TestMethod_2").Should().BeNull("TestMethod should not be available");
+        Assert.Null(typeInfo!.GetFuncDescByName("TestMethod_2"));
     }
 }

--- a/src/dscom.test/tests/PropertyTest.cs
+++ b/src/dscom.test/tests/PropertyTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Runtime.InteropServices;
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -29,12 +30,12 @@ public class PropertyTest : BaseTest
                     .Build();
 
         using var releasableFuncDesc = result.TypeLib.GetTypeInfoByName("TestInterface")?.GetFuncDescByName("Value");
-        releasableFuncDesc.Should().NotBeNull();
-        releasableFuncDesc!.Value.invkind.Should().Be(INVOKEKIND.INVOKE_PROPERTYGET);
-        releasableFuncDesc!.Value.memid.Should().Be(0);
+        Assert.NotNull(releasableFuncDesc);
+        Assert.Equal(INVOKEKIND.INVOKE_PROPERTYGET, releasableFuncDesc!.Value.invkind);
+        Assert.Equal(0, releasableFuncDesc!.Value.memid);
 
         // Check that no unexpected warnings occurred 
-        result.TypeLibExporterNotifySink.ReportedEvents.Should().OnlyContain(x => x.EventKind == ExporterEventKind.NOTIF_TYPECONVERTED);
+        Assert.All(result.TypeLibExporterNotifySink.ReportedEvents, x => Assert.Equal(ExporterEventKind.NOTIF_TYPECONVERTED, x.EventKind));
     }
 
     [Theory]
@@ -53,10 +54,10 @@ public class PropertyTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         // Search for method
-        typeInfo!.ContainsFuncDescByName("TestProperty").Should().Be(true);
+        Assert.True(typeInfo!.ContainsFuncDescByName("TestProperty"));
     }
 
     [Fact]
@@ -74,15 +75,15 @@ public class PropertyTest : BaseTest
 
         //check for source-interface
         var typeSourceInfo = result.TypeLib.GetTypeInfoByName("TestSourceInterface");
-        typeSourceInfo.Should().NotBeNull("TestSourceInterface not found");
+        Assert.NotNull(typeSourceInfo);
 
         //check for test-interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for setter
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestProperty", invokeKind: INVOKEKIND.INVOKE_PROPERTYPUTREF);
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
     }
 
     [Theory]
@@ -122,14 +123,14 @@ public class PropertyTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for setter
         using var funcDescByName = typeInfo!.GetFuncDescByName("TestProperty");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
 
         //check for invokekind
-        funcDescByName!.Value.invkind.Should().Be(invokeKind);
+        Assert.Equal(invokeKind, funcDescByName!.Value.invkind);
     }
 
     [Theory]
@@ -168,20 +169,20 @@ public class PropertyTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         // //check for only one method
         Assert.Throws<COMException>(() => typeInfo!.GetFuncDesc(1, out var ppFuncDesc));
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("Property1");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
-        funcDesc.elemdescFunc.tdesc.vt.Should().Be(type.GetShortVarEnum());
+        Assert.Equal(type.GetShortVarEnum(), funcDesc.elemdescFunc.tdesc.vt);
 
         typeInfo!.GetDocumentation(funcDesc.memid, out var propertyName, out var docString, out var helpContext, out var helpFile);
-        propertyName.Should().Be("Property1");
+        Assert.Equal("Property1", propertyName);
     }
 
     [Theory]
@@ -220,20 +221,20 @@ public class PropertyTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for only one method
         //Assert.Throws<COMException>(() => typeInfo!.GetFuncDesc(1, out var ppFuncDesc));
 
         //check for method
         using var funcDescByName = typeInfo!.GetFuncDescByName("Property1");
-        funcDescByName.Should().NotBeNull();
+        Assert.NotNull(funcDescByName);
         var funcDesc = funcDescByName!.Value;
 
-        funcDesc.elemdescFunc.tdesc.vt.Should().Be((short)VarEnum.VT_VOID);
+        Assert.Equal((short)VarEnum.VT_VOID, funcDesc.elemdescFunc.tdesc.vt);
 
         var elemDesc = Marshal.PtrToStructure<ELEMDESC>(funcDesc.lprgelemdescParam);
-        elemDesc.tdesc.vt.Should().Be(type.GetShortVarEnum());
+        Assert.Equal(type.GetShortVarEnum(), elemDesc.tdesc.vt);
     }
 
     [Theory]
@@ -272,19 +273,19 @@ public class PropertyTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for INVOKE_PROPERTYGET
         using var propGetDescByName = typeInfo!.GetFuncDescByName("Property1", INVOKEKIND.INVOKE_PROPERTYGET);
-        propGetDescByName.Should().NotBeNull();
+        Assert.NotNull(propGetDescByName);
         var propget = propGetDescByName!.Value;
-        propget.elemdescFunc.tdesc.GetVarEnum().Should().Be(type.GetVarEnum());
+        Assert.Equal(type.GetVarEnum(), propget.elemdescFunc.tdesc.GetVarEnum());
 
         //check for INVOKE_PROPERTYPUT
         using var propSetDescByName = typeInfo!.GetFuncDescByName("Property1", INVOKEKIND.INVOKE_PROPERTYPUTREF | INVOKEKIND.INVOKE_PROPERTYPUT);
-        propSetDescByName.Should().NotBeNull();
+        Assert.NotNull(propSetDescByName);
         var propset = propGetDescByName!.Value;
-        propset.elemdescFunc.tdesc.GetVarEnum().Should().Be(type.GetVarEnum());
+        Assert.Equal(type.GetVarEnum(), propset.elemdescFunc.tdesc.GetVarEnum());
     }
 
     [Theory]
@@ -308,8 +309,6 @@ public class PropertyTest : BaseTest
     [InlineData(typeof(Guid))]
     [InlineData(typeof(System.Drawing.Color))]
     [InlineData(typeof(decimal))]
-    [InlineData(typeof(Delegate))]
-    [InlineData(typeof(IntPtr))]
     [InlineData(typeof(IDispatch))]
     [InlineData(typeof(IUnknown))]
     public void DualInterfacePropertyWithSetterAndGetter_IsAvailable(Type type)
@@ -323,19 +322,16 @@ public class PropertyTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
 
         //check for INVOKE_PROPERTYGET
         using var propGetDescByName = typeInfo!.GetFuncDescByName("Property1", INVOKEKIND.INVOKE_PROPERTYGET);
-        propGetDescByName.Should().NotBeNull();
         var propget = propGetDescByName!.Value;
-        propget.elemdescFunc.tdesc.vt.Should().Be(type.GetShortVarEnum());
+        Assert.Equal(type.GetShortVarEnum(), propget.elemdescFunc.tdesc.vt);
 
         //check for INVOKE_PROPERTYPUT
         using var propSetDescByName = typeInfo!.GetFuncDescByName("Property1", INVOKEKIND.INVOKE_PROPERTYPUTREF | INVOKEKIND.INVOKE_PROPERTYPUT);
-        propSetDescByName.Should().NotBeNull();
         var propset = propGetDescByName!.Value;
-        propset.elemdescFunc.tdesc.vt.Should().Be(type.GetShortVarEnum());
+        Assert.Equal(type.GetShortVarEnum(), propset.elemdescFunc.tdesc.vt);
     }
 
     [Theory]
@@ -372,35 +368,35 @@ public class PropertyTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         //check for INVOKE_PROPERTYGET Ptr type
         using var propGetDescByName = typeInfo!.GetFuncDescByName("Property1", INVOKEKIND.INVOKE_PROPERTYGET);
-        propGetDescByName.Should().NotBeNull();
+        Assert.NotNull(propGetDescByName);
         var propget = propGetDescByName!.Value;
-        propget.elemdescFunc.tdesc.vt.Should().Be((short)VarEnum.VT_HRESULT);
+        Assert.Equal((short)VarEnum.VT_HRESULT, propget.elemdescFunc.tdesc.vt);
 
         var firstParameter = propget.GetParameter(0);
-        firstParameter.Should().NotBeNull();
-        firstParameter!.Value.tdesc.vt.Should().Be((short)VarEnum.VT_PTR);
+        Assert.NotNull(firstParameter);
+        Assert.Equal((short)VarEnum.VT_PTR, firstParameter!.Value.tdesc.vt);
 
         // Ptr type should be the final typ
         var value = Marshal.PtrToStructure<TYPEDESC>(firstParameter!.Value.tdesc.lpValue);
-        value.vt.Should().Be(type.GetShortVarEnum());
+        Assert.Equal(type.GetShortVarEnum(), value.vt);
 
         //check for INVOKE_PROPERTYPUT
         using var propSetDescByName = typeInfo!.GetFuncDescByName("Property1", INVOKEKIND.INVOKE_PROPERTYPUTREF | INVOKEKIND.INVOKE_PROPERTYPUT);
-        propSetDescByName.Should().NotBeNull();
+        Assert.NotNull(propSetDescByName);
         var propset = propGetDescByName!.Value;
-        propset.elemdescFunc.tdesc.vt.Should().Be((short)VarEnum.VT_HRESULT);
+        Assert.Equal((short)VarEnum.VT_HRESULT, propset.elemdescFunc.tdesc.vt);
 
         firstParameter = propget.GetParameter(0);
-        firstParameter.Should().NotBeNull();
-        firstParameter!.Value.tdesc.vt.Should().Be((short)VarEnum.VT_PTR);
+        Assert.NotNull(firstParameter);
+        Assert.Equal((short)VarEnum.VT_PTR, firstParameter!.Value.tdesc.vt);
 
         // Ptr type should be the final typ
         value = Marshal.PtrToStructure<TYPEDESC>(firstParameter!.Value.tdesc.lpValue);
-        value.vt.Should().Be(type.GetShortVarEnum());
+        Assert.Equal(type.GetShortVarEnum(), value.vt);
     }
 
     [Fact]
@@ -417,55 +413,55 @@ public class PropertyTest : BaseTest
 
         //check for interface
         var typeInfo = result.TypeLib.GetTypeInfoByName("TestInterface");
-        typeInfo.Should().NotBeNull("TestInterface not found");
+        Assert.NotNull(typeInfo);
 
         // ################### set_Name
 
         typeInfo!.GetFuncDesc(0, out var ppFuncDesc);
-        ppFuncDesc.Should().NotBe(IntPtr.Zero);
+        Assert.NotEqual(IntPtr.Zero, ppFuncDesc);
         var funcDesc = Marshal.PtrToStructure<FUNCDESC>(ppFuncDesc);
-        funcDesc.elemdescFunc.tdesc.vt.Should().Be(typeof(string).GetShortVarEnum());
+        Assert.Equal(typeof(string).GetShortVarEnum(), funcDesc.elemdescFunc.tdesc.vt);
         typeInfo.GetDocumentation(funcDesc.memid, out var propertyName, out _, out _, out _);
-        propertyName.Should().Be("Name");
+        Assert.Equal("Name", propertyName);
 
         // ################### get_Name
 
         typeInfo!.GetFuncDesc(1, out ppFuncDesc);
-        ppFuncDesc.Should().NotBe(IntPtr.Zero);
+        Assert.NotEqual(IntPtr.Zero, ppFuncDesc);
         funcDesc = Marshal.PtrToStructure<FUNCDESC>(ppFuncDesc);
-        funcDesc.elemdescFunc.tdesc.vt.Should().Be((short)VarEnum.VT_VOID);
+        Assert.Equal((short)VarEnum.VT_VOID, funcDesc.elemdescFunc.tdesc.vt);
 
         var elemDesc = Marshal.PtrToStructure<ELEMDESC>(funcDesc.lprgelemdescParam);
-        elemDesc.tdesc.vt.Should().Be(typeof(string).GetShortVarEnum());
+        Assert.Equal(typeof(string).GetShortVarEnum(), elemDesc.tdesc.vt);
 
         Marshal.PtrToStructure<FUNCDESC>(ppFuncDesc);
 
         typeInfo.GetDocumentation(funcDesc.memid, out propertyName, out _, out _, out _);
-        propertyName.Should().Be("Name");
+        Assert.Equal("Name", propertyName);
 
         // ################### set_Value
 
         typeInfo!.GetFuncDesc(2, out ppFuncDesc);
-        ppFuncDesc.Should().NotBe(IntPtr.Zero);
+        Assert.NotEqual(IntPtr.Zero, ppFuncDesc);
         funcDesc = Marshal.PtrToStructure<FUNCDESC>(ppFuncDesc);
-        funcDesc.elemdescFunc.tdesc.vt.Should().Be(typeof(int).GetShortVarEnum());
+        Assert.Equal(typeof(int).GetShortVarEnum(), funcDesc.elemdescFunc.tdesc.vt);
 
         typeInfo.GetDocumentation(funcDesc.memid, out propertyName, out _, out _, out _);
-        propertyName.Should().Be("Value");
+        Assert.Equal("Value", propertyName);
 
         // ################### get_Value
 
         typeInfo!.GetFuncDesc(3, out ppFuncDesc);
-        ppFuncDesc.Should().NotBe(IntPtr.Zero);
+        Assert.NotEqual(IntPtr.Zero, ppFuncDesc);
         funcDesc = Marshal.PtrToStructure<FUNCDESC>(ppFuncDesc);
-        funcDesc.elemdescFunc.tdesc.vt.Should().Be((short)VarEnum.VT_VOID);
+        Assert.Equal((short)VarEnum.VT_VOID, funcDesc.elemdescFunc.tdesc.vt);
 
         elemDesc = Marshal.PtrToStructure<ELEMDESC>(funcDesc.lprgelemdescParam);
-        elemDesc.tdesc.vt.Should().Be(typeof(int).GetShortVarEnum());
+        Assert.Equal(typeof(int).GetShortVarEnum(), elemDesc.tdesc.vt);
 
         Marshal.PtrToStructure<FUNCDESC>(ppFuncDesc);
 
         typeInfo.GetDocumentation(funcDesc.memid, out propertyName, out _, out _, out _);
-        propertyName.Should().Be("Value");
+        Assert.Equal("Value", propertyName);
     }
 }

--- a/src/dscom.test/tests/RegistrationServicesTest.cs
+++ b/src/dscom.test/tests/RegistrationServicesTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Runtime.InteropServices;
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -42,13 +43,13 @@ public class RegistrationServicesTest : BaseTest
             _guidOfiClassFactory) as IClassFactory;
 
         // Create instance of IRegistrationServicesTestInterface
-        classFactory.Should().NotBeNull();
+        Assert.NotNull(classFactory);
         classFactory!.CreateInstance(null!, ref _guidOfRegistrationServicesTestInterface, out var ppvObject);
 
         // IRegistrationServicesTestInterface should be available
         var testInstance = Marshal.GetObjectForIUnknown(ppvObject) as IRegistrationServicesTestInterface;
-        testInstance.Should().NotBeNull();
-        testInstance!.GetSuccessString().Should().Be("Success");
+        Assert.NotNull(testInstance);
+        Assert.Equal("Success", testInstance!.GetSuccessString());
 
         // Cleanup
         registrationServices.UnregisterTypeForComClients(cookie);
@@ -62,11 +63,10 @@ public class RegistrationServicesTest : BaseTest
             ComTypes.RegistrationClassContext.LocalServer,
             ComTypes.RegistrationConnectionType.MultipleUse);
 
-        Ole32.CoGetClassObject(_guidOfRegistrationServicesTestClass,
+        Assert.NotNull(Ole32.CoGetClassObject(_guidOfRegistrationServicesTestClass,
             (uint)ComTypes.RegistrationClassContext.LocalServer,
             IntPtr.Zero,
-            _guidOfiClassFactory)
-                .Should().NotBeNull().And.BeAssignableTo<IClassFactory>();
+            _guidOfiClassFactory));
 
         registrationServices.UnregisterTypeForComClients(cookie);
 
@@ -78,7 +78,7 @@ public class RegistrationServicesTest : BaseTest
                 _guidOfiClassFactory);
         });
 
-        exception.HResult.Should().Be(HRESULT.REGDB_E_CLASSNOTREG);
+        Assert.Equal(HRESULT.REGDB_E_CLASSNOTREG, exception.HResult);
     }
 
     [Fact]
@@ -94,22 +94,21 @@ public class RegistrationServicesTest : BaseTest
             _guidOfiClassFactory) as IClassFactory;
 
         // Create instance of IRegistrationServicesTestInterface
-        classFactory.Should().NotBeNull();
+        Assert.NotNull(classFactory);
         classFactory!.CreateInstance(null!, ref _guidOfRegistrationServicesTestInterface, out var ppvObject1);
         var testInstance1 = Marshal.GetObjectForIUnknown(ppvObject1) as IRegistrationServicesTestInterface;
-        testInstance1.Should().NotBeNull();
+        Assert.NotNull(testInstance1);
         var pid1 = testInstance1!.GetPid();
 
-        classFactory.Should().NotBeNull();
         classFactory!.CreateInstance(null!, ref _guidOfRegistrationServicesTestInterface, out var ppvObject2);
         var testInstance2 = Marshal.GetObjectForIUnknown(ppvObject2) as IRegistrationServicesTestInterface;
-        testInstance2.Should().NotBeNull();
+        Assert.NotNull(testInstance2);
         var pid2 = testInstance2!.GetPid();
 
         // In case of a InprocServer this test is actually unnecessary, because the test uses the unit test runtime process
-        pid2.Should().NotBe(0);
-        pid2.Should().NotBe(0);
-        pid1.Should().Be(pid2);
+        Assert.NotEqual(0, pid2);
+        Assert.NotEqual(0, pid2);
+        Assert.Equal(pid1, pid2);
 
         // Cleanup
         registrationServices.UnregisterTypeForComClients(cookie);
@@ -125,7 +124,7 @@ public class RegistrationServicesTest : BaseTest
 
         // this is not testable in a InprocServer. Only check if RegisterTypeForComClients returns a cookie
 
-        cookie.Should().NotBe(0);
+        Assert.NotEqual(0, cookie);
 
         // Cleanup
         registrationServices.UnregisterTypeForComClients(cookie);
@@ -147,7 +146,7 @@ public class RegistrationServicesTest : BaseTest
                 _guidOfiClassFactory);
         });
 
-        exception.HResult.Should().Be(HRESULT.REGDB_E_CLASSNOTREG);
+        Assert.Equal(HRESULT.REGDB_E_CLASSNOTREG, exception.HResult);
         registrationServices.UnregisterTypeForComClients(cookie);
     }
 
@@ -159,13 +158,12 @@ public class RegistrationServicesTest : BaseTest
             ComTypes.RegistrationClassContext.LocalServer,
             ComTypes.RegistrationConnectionType.Suspended);
 
-        Ole32.CoResumeClassObjects().Should().Be(HRESULT.S_OK);
+        Assert.Equal(HRESULT.S_OK, Ole32.CoResumeClassObjects());
 
-        Ole32.CoGetClassObject(_guidOfRegistrationServicesTestClass,
+        Assert.NotNull(Ole32.CoGetClassObject(_guidOfRegistrationServicesTestClass,
             (uint)ComTypes.RegistrationClassContext.LocalServer,
             IntPtr.Zero,
-            _guidOfiClassFactory)
-            .Should().NotBeNull().And.BeAssignableTo<IClassFactory>();
+            _guidOfiClassFactory));
 
         // Cleanup
         registrationServices.UnregisterTypeForComClients(cookie);

--- a/src/dscom.test/tests/StructTest.cs
+++ b/src/dscom.test/tests/StructTest.cs
@@ -14,6 +14,7 @@
 
 using System.Collections;
 using System.Runtime.InteropServices;
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -86,20 +87,20 @@ public class StructTest : BaseTest
     {
         var fieldName = ValidChars.Replace($"Field_{type}", "_");
         var testStruct = AssemblyBuilderResult.TypeLib.GetTypeInfoByName(StructName);
-        testStruct.Should().NotBeNull($"Struct {StructName} should exist");
+        Assert.NotNull(testStruct);
 
         // Check field exist
         using var vardesc = testStruct!.GetVarDescByName(fieldName);
-        vardesc.Should().NotBeNull($"Field {fieldName} should exist in struct {StructName}");
+        Assert.NotNull(vardesc);
 
         // Check field type
-        vardesc!.Value.elemdescVar.tdesc.GetVarEnum().Should().Be(expectedType, $"Field {fieldName} should be {expectedType}");
+        Assert.Equal(expectedType, vardesc!.Value.elemdescVar.tdesc.GetVarEnum());
 
         // Check field sub type
         if (expectedSubType != null)
         {
             var subtypeDesc = Marshal.PtrToStructure<TYPEDESC>(vardesc!.Value.elemdescVar.tdesc.lpValue);
-            subtypeDesc.GetVarEnum().Should().Be(expectedSubType, $"Field {fieldName} inner type should be {expectedSubType}");
+            Assert.Equal(expectedSubType, subtypeDesc.GetVarEnum());
         }
     }
 
@@ -107,11 +108,11 @@ public class StructTest : BaseTest
     public void StructWithFields_SizeIs136()
     {
         var testStruct = AssemblyBuilderResult.TypeLib.GetTypeInfoByName(StructName);
-        testStruct.Should().NotBeNull($"Struct {StructName} should exist");
+        Assert.NotNull(testStruct);
 
         using var attributes = testStruct!.GetTypeInfoAttributes();
-        attributes.Should().NotBeNull();
+        Assert.NotNull(attributes);
 
-        attributes!.Value.cbSizeInstance.Should().Be(136);
+        Assert.Equal(136, attributes!.Value.cbSizeInstance);
     }
 }

--- a/src/dscom.test/tests/TypeLibTest.cs
+++ b/src/dscom.test/tests/TypeLibTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Runtime.InteropServices;
+using Xunit;
 
 namespace dSPACE.Runtime.InteropServices.Tests;
 
@@ -29,10 +30,10 @@ public class TypeLibTest : BaseTest
         var result = builder.Build();
 
         using var attributes = result.TypeLib.GetTypeLibAttributes();
-        attributes.Should().NotBeNull();
+        Assert.NotNull(attributes);
 
-        attributes!.Value.wMajorVerNum.Should().Be(999);
-        attributes!.Value.wMinorVerNum.Should().Be(888);
+        Assert.Equal(999, attributes!.Value.wMajorVerNum);
+        Assert.Equal(888, attributes!.Value.wMinorVerNum);
     }
 
     [Fact]
@@ -44,10 +45,10 @@ public class TypeLibTest : BaseTest
         var result = builder.Build();
 
         using var attributes = result.TypeLib.GetTypeLibAttributes();
-        attributes.Should().NotBeNull();
+        Assert.NotNull(attributes);
 
-        attributes!.Value.wMajorVerNum.Should().Be(777);
-        attributes!.Value.wMinorVerNum.Should().Be(666);
+        Assert.Equal(777, attributes!.Value.wMajorVerNum);
+        Assert.Equal(666, attributes!.Value.wMinorVerNum);
     }
 
     [Fact]
@@ -61,10 +62,10 @@ public class TypeLibTest : BaseTest
         var result = builder.Build();
 
         using var attributes = result.TypeLib.GetTypeLibAttributes();
-        attributes.Should().NotBeNull();
+        Assert.NotNull(attributes);
 
-        attributes!.Value.wMajorVerNum.Should().Be(555);
-        attributes!.Value.wMinorVerNum.Should().Be(444);
+        Assert.Equal(555, attributes!.Value.wMajorVerNum);
+        Assert.Equal(444, attributes!.Value.wMinorVerNum);
     }
 
     [Fact]
@@ -74,9 +75,9 @@ public class TypeLibTest : BaseTest
         var result = builder.Build();
 
         using var attributes = result.TypeLib.GetTypeLibAttributes();
-        attributes.Should().NotBeNull();
+        Assert.NotNull(attributes);
 
-        attributes!.Value.wLibFlags.Should().Be(0);
+        Assert.Equal(0, (int)attributes!.Value.wLibFlags);
     }
 
     [Fact]
@@ -86,9 +87,9 @@ public class TypeLibTest : BaseTest
         var result = builder.Build();
 
         using var attributes = result.TypeLib.GetTypeLibAttributes();
-        attributes.Should().NotBeNull();
+        Assert.NotNull(attributes);
 
-        attributes!.Value.syskind.Should().Be(SYSKIND.SYS_WIN64);
+        Assert.Equal(SYSKIND.SYS_WIN64, attributes!.Value.syskind);
     }
 
     [Fact]
@@ -98,9 +99,9 @@ public class TypeLibTest : BaseTest
         var result = builder.Build();
 
         using var attributes = result.TypeLib.GetTypeLibAttributes();
-        attributes.Should().NotBeNull();
+        Assert.NotNull(attributes);
 
-        attributes!.Value.lcid.Should().Be(0);
+        Assert.Equal(0, attributes!.Value.lcid);
     }
 
     [Fact]
@@ -115,7 +116,7 @@ public class TypeLibTest : BaseTest
         Assert.NotNull(pVarVal);
         var customDataString = pVarVal.ToString();
 
-        customDataString.Should().Be(builder.AssemblyBuilder.ToString());
+        Assert.Equal(builder.AssemblyBuilder.ToString(), customDataString);
     }
 
     [Fact]
@@ -125,7 +126,7 @@ public class TypeLibTest : BaseTest
         var result = builder.Build();
         result.TypeLib.GetDocumentation(-1, out var strTypeLibName, out _, out _, out _);
 
-        strTypeLibName.Should().Be(builder.Assembly.GetName().Name);
+        Assert.Equal(builder.Assembly.GetName().Name, strTypeLibName);
     }
 
     [Fact]
@@ -134,15 +135,15 @@ public class TypeLibTest : BaseTest
         var firstresult = CreateAssembly(CreateAssemblyName(minor: 1, major: 0)).Build();
 
         using var firstattributes = firstresult.TypeLib.GetTypeLibAttributes();
-        firstattributes.Should().NotBeNull();
+        Assert.NotNull(firstattributes);
         var firstGuid = firstattributes!.Value.guid;
 
         var secondresult = CreateAssembly(CreateAssemblyName(minor: 2, major: 0)).Build();
         using var secondattributes = secondresult.TypeLib.GetTypeLibAttributes();
-        secondattributes.Should().NotBeNull();
+        Assert.NotNull(secondattributes);
         var secondGuid = secondattributes!.Value.guid;
 
-        secondGuid.Should().NotBe(firstGuid);
+        Assert.NotEqual(firstGuid, secondGuid);
     }
 
     [Fact]
@@ -151,15 +152,15 @@ public class TypeLibTest : BaseTest
         var firstresult = CreateAssembly(CreateAssemblyName(minor: 1, major: 0)).Build();
 
         using var firstattributes = firstresult.TypeLib.GetTypeLibAttributes();
-        firstattributes.Should().NotBeNull();
+        Assert.NotNull(firstattributes);
         var firstGuid = firstattributes!.Value.guid;
 
         var secondresult = CreateAssembly(CreateAssemblyName(minor: 1, major: 1)).Build();
         using var secondattributes = secondresult.TypeLib.GetTypeLibAttributes();
-        secondattributes.Should().NotBeNull();
+        Assert.NotNull(secondattributes);
 
         var secondGuid = secondattributes!.Value.guid;
-        secondGuid.Should().NotBe(firstGuid);
+        Assert.NotEqual(firstGuid, secondGuid);
     }
 
     [Fact]
@@ -168,10 +169,10 @@ public class TypeLibTest : BaseTest
         var result = CreateAssembly(CreateAssemblyName(major: 3, minor: 4)).Build();
 
         using var attributes = result.TypeLib.GetTypeLibAttributes();
-        attributes.Should().NotBeNull();
+        Assert.NotNull(attributes);
 
-        attributes!.Value.wMajorVerNum.Should().Be(3);
-        attributes!.Value.wMinorVerNum.Should().Be(4);
+        Assert.Equal(3, attributes!.Value.wMajorVerNum);
+        Assert.Equal(4, attributes!.Value.wMinorVerNum);
     }
 
     [Fact]
@@ -180,10 +181,10 @@ public class TypeLibTest : BaseTest
         var result = CreateAssembly().Build();
 
         using var attributes = result.TypeLib.GetTypeLibAttributes();
-        attributes.Should().NotBeNull();
+        Assert.NotNull(attributes);
 
-        attributes!.Value.wMajorVerNum.Should().Be(1);
-        attributes!.Value.wMinorVerNum.Should().Be(0);
+        Assert.Equal(1, attributes!.Value.wMajorVerNum);
+        Assert.Equal(0, attributes!.Value.wMinorVerNum);
     }
 
     [Fact]
@@ -191,9 +192,9 @@ public class TypeLibTest : BaseTest
     {
         var result = CreateAssembly().Build(false);
         using var attributes = result.TypeLib.GetTypeLibAttributes();
-        attributes.Should().NotBeNull();
+        Assert.NotNull(attributes);
 
-        attributes!.Value.wLibFlags.Should().Be(0);
+        Assert.Equal(0, (int)attributes!.Value.wLibFlags);
     }
 
     [Fact]
@@ -202,15 +203,15 @@ public class TypeLibTest : BaseTest
         var firstresult = CreateAssembly(CreateAssemblyName(assemblyNameSuffix: "1")).Build();
 
         using var firstattributes = firstresult.TypeLib.GetTypeLibAttributes();
-        firstattributes.Should().NotBeNull();
+        Assert.NotNull(firstattributes);
         var firstGuid = firstattributes!.Value.guid;
 
         var secondresult = CreateAssembly(CreateAssemblyName(assemblyNameSuffix: "2")).Build();
         using var secondattributes = secondresult.TypeLib.GetTypeLibAttributes();
-        secondattributes.Should().NotBeNull();
+        Assert.NotNull(secondattributes);
         var secondGuid = secondattributes!.Value.guid;
 
-        secondGuid.Should().NotBe(firstGuid);
+        Assert.NotEqual(firstGuid, secondGuid);
     }
 
     [Fact]
@@ -227,18 +228,18 @@ public class TypeLibTest : BaseTest
             new CustomAttributeBuilder[] { customAttributeBuilder }).Build();
 
         using var attributes = firstresult.TypeLib.GetTypeLibAttributes();
-        attributes.Should().NotBeNull();
+        Assert.NotNull(attributes);
         var firstGuid = attributes!.Value.guid;
 
         var secondresult = CreateAssembly(
             CreateAssemblyName(major: 3, minor: 4),
             new CustomAttributeBuilder[] { customAttributeBuilder }).Build();
         using var secondattributes = secondresult.TypeLib.GetTypeLibAttributes();
-        secondattributes.Should().NotBeNull();
+        Assert.NotNull(secondattributes);
         var secondGuid = secondattributes!.Value.guid;
 
-        firstGuid.Should().Be(new Guid(guidString));
-        secondGuid.Should().Be(new Guid(guidString));
+        Assert.Equal(new Guid(guidString), firstGuid);
+        Assert.Equal(new Guid(guidString), secondGuid);
     }
 
     [Fact]
@@ -247,7 +248,7 @@ public class TypeLibTest : BaseTest
         var result = CreateAssembly().WithCustomAttribute<AssemblyDescriptionAttribute>("Test").Build();
         result.TypeLib.GetDocumentation(-1, out _, out var docString, out _, out _);
 
-        docString.Should().Be("Test");
+        Assert.Equal("Test", docString);
     }
 
     [Fact]
@@ -271,19 +272,19 @@ public class TypeLibTest : BaseTest
 
         // check for class
         var typeInfo = assemblyB.TypeLib.GetTypeInfoByName("TestClassB");
-        typeInfo.Should().NotBeNull("TestClassB not found");
+        Assert.NotNull(typeInfo);
 
         // check for 'some' property
         using var some_property_funcdesc = typeInfo!.GetFuncDescByName("Some");
-        some_property_funcdesc.Should().NotBeNull();
+        Assert.NotNull(some_property_funcdesc);
 
-        some_property_funcdesc!.Value!.elemdescFunc.tdesc.vt.Should().Be((short)VarEnum.VT_PTR, "type is known");
+        Assert.Equal((short)VarEnum.VT_PTR, some_property_funcdesc!.Value!.elemdescFunc.tdesc.vt);
 
         // check for 'other' property
         using var other_property_funcdesc = typeInfo!.GetFuncDescByName("Other");
-        other_property_funcdesc.Should().NotBeNull();
+        Assert.NotNull(other_property_funcdesc);
 
-        other_property_funcdesc!.Value!.elemdescFunc.tdesc.vt.Should().Be((short)VarEnum.VT_PTR, "type is known");
+        Assert.Equal((short)VarEnum.VT_PTR, other_property_funcdesc!.Value!.elemdescFunc.tdesc.vt);
     }
 
     [Fact]
@@ -307,18 +308,18 @@ public class TypeLibTest : BaseTest
 
         // check for class
         var typeInfo = assemblyB.TypeLib.GetTypeInfoByName("TestClassB");
-        typeInfo.Should().NotBeNull("TestClassB not found");
+        Assert.NotNull(typeInfo);
 
         // check for 'other' property
         using var other_property_funcdesc = typeInfo!.GetFuncDescByName("Other");
-        other_property_funcdesc.Should().NotBeNull();
+        Assert.NotNull(other_property_funcdesc);
 
-        other_property_funcdesc!.Value!.elemdescFunc.tdesc.vt.Should().Be((short)VarEnum.VT_PTR, "type is known");
+        Assert.Equal((short)VarEnum.VT_PTR, other_property_funcdesc!.Value!.elemdescFunc.tdesc.vt);
 
         // check for 'some' property
         using var some_property_funcdesc = typeInfo!.GetFuncDescByName("Some");
-        some_property_funcdesc.Should().NotBeNull();
+        Assert.NotNull(some_property_funcdesc);
 
-        some_property_funcdesc!.Value!.elemdescFunc.tdesc.vt.Should().Be((short)VarEnum.VT_PTR, "type is known");
+        Assert.Equal((short)VarEnum.VT_PTR, some_property_funcdesc!.Value!.elemdescFunc.tdesc.vt);
     }
 }


### PR DESCRIPTION
# Removed FluentAssertions

[https://github.com/fluentassertions/fluentassertions/pull/2943](https://github.com/fluentassertions/fluentassertions/pull/2943)

Fluent assertions has changed its license model.  

See video from Nick: [https://www.youtube.com/watch?v=ZFc6jcaM6Ms&t=2s](https://www.youtube.com/watch?v=ZFc6jcaM6Ms&t=2s)

Fluent assertions is just a **nice to have** library.  
All functions can also be replaced by the classic `Xunit.Assert`. This is not fluent but who cares.  
I would not recommend any company to use FluentAssertions and then pay 130$ per developer for it.  
If you had never had a library like fluentassertions before, nobody would have thought of paying 130$ for it.  

I understand it when it comes to a library where there is still a lot of development work to be done.   
But the FluentAssertions Library is feature complete.   

If I change the license of a library that is actually in maintanance mode, then it is a bit immoral to ask for money now if you have pushed another commercial library out of the market for years by making your library open source.   

<https://www.reddit.com/r/dotnet/comments/1i17jm0/fluentassertions_becomes_paid_software_for/?rdt=58726>

> There are many reasons why a person would not want to be paid for their open source work.
> - They may already have a full-time job that they love, which enables them to contribute to open source in their spare time.


[https://opensource.guide/getting-paid/](https://opensource.guide/getting-paid/)

Modern companies encourage their employees to participate in open source even during their working hours.  
None of us developers can give away our working time without financial compensation.  
Btw. Thank you dSPACE for allowing us to contribute to open source projects .
Even if DSCOM is only a small library, we remain OpenSource and free for use ;-) 

This is just my opinion ❤️