### PR TITLE
add support for pointer types for method parameter

### DIFF
--- a/src/dscom/TypeProvider.cs
+++ b/src/dscom/TypeProvider.cs
@@ -326,6 +326,35 @@ internal sealed class TypeProvider
                     // struct
                     return VarEnum.VT_USERDEFINED;
                 }
+                else if (type.IsPointer)
+                {
+                    parentLevel = VarEnum.VT_PTR;
+                    switch (type.FullName)
+                    {
+                        case "System.Byte*":
+                            return VarEnum.VT_UI1;
+                        case "System.Char*":
+                            return IsMethod ? VarEnum.VT_UI2 : VarEnum.VT_UI1;
+                        case "System.SByte*":
+                            return VarEnum.VT_I1;
+                        case "System.Int16*":
+                            return VarEnum.VT_I2;
+                        case "System.UInt16*":
+                            return VarEnum.VT_UI2;
+                        case "System.Int32*":
+                            return VarEnum.VT_I4;
+                        case "System.UInt32*":
+                            return VarEnum.VT_UI4;
+                        case "System.Int64*":
+                            return VarEnum.VT_I8;
+                        case "System.UInt64*":
+                            return VarEnum.VT_UI8;
+                        case "System.Single*":
+                            return VarEnum.VT_R4;
+                        case "System.Double*":
+                            return VarEnum.VT_R8;
+                    }
+                }
 
                 if (Context.TypeInfoResolver.ResolveDefaultCoClassInterface(type) != null)
                 {


### PR DESCRIPTION
We are currently replacing tlbexp with dscom and faced an incompatibility that should be fixed with this pull request. Consider following COM interface:
    [
        Guid("XXX-Y-Y-Y-ZZZZZ"),
        ComVisible(true)
    ]
    public interface IMethodsWithPointers
    {
        unsafe void TheMethod(uint pixelInLine, ushort* pInput);
    };

tlbexp renders it to TLB as
    [...]
    interface IMethodsWithPointers : IUnknown {
        HRESULT _stdcall TheMethod([in] unsigned long pixelInLine, [in, out] unsigned short* pInput);
    };

dscom delivers following TLB definition:
    [...]
    interface IMethodsWithPointers : IUnknown {
        HRESULT _stdcall TheMethod([in] unsigned long pixelInLine, [in] IUnknown* pInput);
    };

Obviously dscom doesn't process C# pointer types properly, this has to be adressed by my change.