### PR TITLE
build!: Removed dotnet 6

### DIFF
--- a/.github/workflows/example-test.yaml
+++ b/.github/workflows/example-test.yaml
@@ -12,8 +12,8 @@ jobs:
         test_suite:
           - name: OutProc
             path: outproc
-          # - name: 32 Bit
-          #   path: 32bit
+          - name: 32 Bit
+            path: 32bit
           - name: C++/CLI
             path: cppcli
 

--- a/.github/workflows/example-test.yaml
+++ b/.github/workflows/example-test.yaml
@@ -12,8 +12,8 @@ jobs:
         test_suite:
           - name: OutProc
             path: outproc
-          - name: 32 Bit
-            path: 32bit
+          # - name: 32 Bit
+          #   path: 32bit
           - name: C++/CLI
             path: cppcli
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,19 +53,19 @@ jobs:
         working-directory: src/dscom.build/bin/Release
 
       - name: Publish 32Bit binary
-        run: dotnet publish .\src\dscom.client\dscom.client.csproj --no-self-contained -c Release -r win-x86 -f net6.0 /p:PublishSingleFile=true; copy src\dscom.client\bin\Release\net6.0\win-x86\publish\dscom.exe src\dscom.client\bin\Release\net6.0\win-x86\publish\dscom32.exe
+        run: dotnet publish .\src\dscom.client\dscom.client.csproj --no-self-contained -c Release -r win-x86 -f net8.0 /p:PublishSingleFile=true; copy src\dscom.client\bin\Release\net8.0\win-x86\publish\dscom.exe src\dscom.client\bin\Release\net8.0\win-x86\publish\dscom32.exe
 
       - name: Release 32Bit binary
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: src/dscom.client/bin/Release/net6.0/win-x86/publish/dscom32.exe
+          files: src/dscom.client/bin/Release/net8.0/win-x86/publish/dscom32.exe
 
       - name: Publish 64Bit binary
-        run: dotnet publish .\src\dscom.client\dscom.client.csproj --no-self-contained -c Release -r win-x64 -f net6.0 /p:PublishSingleFile=true
+        run: dotnet publish .\src\dscom.client\dscom.client.csproj --no-self-contained -c Release -r win-x64 -f net8.0 /p:PublishSingleFile=true
 
       - name: Release 64Bit binary
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: src/dscom.client/bin/Release/net6.0/win-x64/publish/dscom.exe
+          files: src/dscom.client/bin/Release/net8.0/win-x64/publish/dscom.exe

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ The result should be a line as follows in your `.csproj` file:
     </PackageReference>
 ```
 
-**Note**: The extra attribute `NoWarn="NU1701"` is only required, if neither `.NET 4.8` nor `.NET 6.0` are targeted, since dotnet pack will currently not create a .NETStandard 2.0 compliant NuGet Package.
+**Note**: The extra attribute `NoWarn="NU1701"` is only required, if neither `.NET 4.8` nor `.NET 8.0` are targeted, since dotnet pack will currently not create a .NETStandard 2.0 compliant NuGet Package.
 
 #### Enforcing to stop the build, if an error occurs
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The `dSPACE.Runtime.InteropServices.BuildTasks` library provides build tasks whi
 
 - [dSPACE COM tools](#dspace-com-tools)
   - [Command Line Client](#command-line-client)
+    - [Key Features of `dscom.exe`](#key-features-of-dscomexe)
     - [Installation](#installation)
     - [Usage](#usage)
   - [Library](#library)
@@ -47,6 +48,7 @@ The `dSPACE.Runtime.InteropServices.BuildTasks` library provides build tasks whi
   - [Migration notes (mscorelib vs System.Private.CoreLib)](#migration-notes-mscorelib-vs-systemprivatecorelib)
     - [Why can I load a .NET Framework library into a .NET application?](#why-can-i-load-a-net-framework-library-into-a-net-application)
   - [Limitations](#limitations)
+    - [.NET 6 support](#net-6-support)
     - [RegisterAssembly](#registerassembly)
     - [RegAsm](#regasm)
   - [Contributing](#contributing)
@@ -453,6 +455,15 @@ classextern forwarder System.Exception
 - No support for `UnmanagedType.CustomMarshaler`
 - No support for .NET Framework assemblies with `AssemblyMetadataAttribute` value ".NETFrameworkAssembly"
 - Using DsComTypeLibraryEmbedAfterBuild=true in combination with the Default ComHost due to a cyclic dependency in .NET SDK [#286](https://github.com/dspace-group/dscom/issues/286).
+
+### .NET 6 support
+
+.NET 6 is no longer supported by this project. Please use .NET 8 or later for full compatibility and support. If you require .NET 6 support, consider using an older release of dscom, but note that new features and bug fixes will not be backported.
+
+Latest .NET compatible version is `1.15.2`.
+
+- [https://github.com/dspace-group/dscom/releases/tag/v1.15.2](https://github.com/dspace-group/dscom/releases/tag/v1.15.2)
+- [https://www.nuget.org/packages/dscom/1.15.2](https://www.nuget.org/packages/dscom/1.15.2)
 
 ### RegisterAssembly
 

--- a/examples/32bit/README.md
+++ b/examples/32bit/README.md
@@ -13,7 +13,7 @@ This example shows how to build a 32bit application with a .NET COM server and a
     `.\bin\dscom32.exe tlbregister <YOUR-REPO-PATH>\comtestdotnet\comtestdotnet.tlb`
 
 5. Register the COM server as **Adminstrator**:  
- `regsvr32.exe <YOUR-REPO-PATH>\comtestdotnet\bin\Debug\net6.0\win-x86\comtestdotnet.comhost.dll
+ `regsvr32.exe <YOUR-REPO-PATH>\comtestdotnet\bin\Debug\net8.0\win-x86\comtestdotnet.comhost.dll
 `
 
 6. Open Visual Studio 2022. Compile and run the application as **x86**.

--- a/examples/32bit/comtestdotnet/comtestdotnet.csproj
+++ b/examples/32bit/comtestdotnet/comtestdotnet.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Platforms>AnyCPU;x86</Platforms>

--- a/examples/32bit/scripts/create-tlb.bat
+++ b/examples/32bit/scripts/create-tlb.bat
@@ -16,9 +16,9 @@ if not exist %dscom32% (
 )
 
 dotnet build --framework net48 -c Release %~dp0\..\comtestdotnet\comtestdotnet.csproj
-dotnet build --framework net6.0 -c Release %~dp0\..\comtestdotnet\comtestdotnet.csproj
+dotnet build --framework net8.0 -c Release %~dp0\..\comtestdotnet\comtestdotnet.csproj
 
-SET dll60=%~dp0\..\comtestdotnet\bin\Release\net6.0\comtestdotnet.dll
+SET dll60=%~dp0\..\comtestdotnet\bin\Release\net8.0\comtestdotnet.dll
 SET dll48=%~dp0\..\comtestdotnet\bin\Release\net48\comtestdotnet.dll
 
 %dscom% tlbexport %dll60% --out %~dp0\tlb-comtestdotnet-dscom-64.tlb

--- a/examples/32bit/scripts/msbuild-acceptance-test.cmd
+++ b/examples/32bit/scripts/msbuild-acceptance-test.cmd
@@ -39,17 +39,7 @@ dotnet build-server shutdown
 
 dotnet msbuild -nodeReuse:False -t:Build -p:Configuration=Release -p:Platform=x64 -p:TargetPlatform=net48 -p:PerformAcceptanceTest=Runtime -bl:%~dp0\net48x64.binlog
 
-SET ERRUNTIMEX64_NET48=%ERRORLEVEL%
-
-dotnet build-server shutdown
-
-dotnet msbuild -nodeReuse:False -t:Restore -p:Configuration=Release -p:Platform=x64 -p:TargetPlatform=net6.0-windows -p:PerformAcceptanceTest=Runtime
-
-dotnet build-server shutdown
-
-dotnet msbuild -nodeReuse:False -t:Build -p:Configuration=Release -p:Platform=x64 -p:TargetPlatform=net6.0-windows -p:PerformAcceptanceTest=Runtime -bl:%~dp0\net60x64.binlog
-
-SET ERRUNTIMEX64_NET60=%ERRORLEVEL%
+SET ERRUNTIMEX64_net80=%ERRORLEVEL%
 
 dotnet build-server shutdown
 
@@ -69,15 +59,6 @@ dotnet build-server shutdown
 
 dotnet msbuild -nodeReuse:False -t:Build -p:Configuration=Release -p:Platform=x86 -p:TargetPlatform=net48 -p:PerformAcceptanceTest=Runtime -bl:%~dp0\net48x86.binlog
 SET ERRUNTIMEX86_NET48=%ERRORLEVEL%
-
-dotnet build-server shutdown
-
-dotnet msbuild -nodeReuse:False -t:Restore -p:Configuration=Release -p:Platform=x86 -p:TargetPlatform=net6.0-windows -p:PerformAcceptanceTest=Runtime
-
-dotnet build-server shutdown
-
-dotnet msbuild -nodeReuse:False -t:Build -p:Configuration=Release -p:Platform=x86 -p:TargetPlatform=net6.0-windows -p:PerformAcceptanceTest=Runtime -bl:%~dp0\net60x86.binlog
-SET ERRUNTIMEX86_NET60=%ERRORLEVEL%
 
 dotnet build-server shutdown
 
@@ -103,7 +84,7 @@ IF NOT "%ERRUNTIMEX64_NET48%" == "0" (
   ECHO "::warning::Runtime specific acceptance test for platform x64 using .NET FullFramework 4.8 failed."
 )
 
-IF NOT "%ERRUNTIMEX64_NET60%" == "0" (
+IF NOT "%ERRUNTIMEX64_net80%" == "0" (
   SET EXITCODE=1
   ECHO "::warning::Runtime specific acceptance test for platform x64 using .NET 6.0 failed."
 )
@@ -123,19 +104,9 @@ IF NOT "%ERRUNTIMEX86_NET80%" == "0" (
   ECHO "::warning::Runtime specific acceptance test for platform x86 using .NET 8.0 failed."
 )
 
-IF NOT "%ERRUNTIMEX86_NET60%" == "0" (
+IF NOT "%ERRUNTIMEX86_net80%" == "0" (
   ::SET EXITCODE=1
   ECHO "::warning::Runtime specific acceptance test for platform x64 using .NET 6.0 failed."
-)
-
-IF NOT EXIST %~dp0\..\comtestdotnet\bin\x64\Release\net6.0\comtestdotnet.tlb (
-  SET EXITCODE=1
-  ECHO "::warning::Could not find exported TLB file for .NET 6 (x64)"
-)
-
-IF NOT EXIST %~dp0\..\comtestdotnet\bin\x86\Release\net6.0\comtestdotnet.tlb (
-  ::SET EXITCODE=1
-  ECHO "::warning::Could not find exported TLB file for .NET 6 (x86)"
 )
 
 IF NOT EXIST %~dp0\..\comtestdotnet\bin\x64\Release\net48\comtestdotnet.tlb (

--- a/examples/32bit/scripts/msbuild-acceptance-test.cmd
+++ b/examples/32bit/scripts/msbuild-acceptance-test.cmd
@@ -84,11 +84,6 @@ IF NOT "%ERRUNTIMEX64_NET48%" == "0" (
   ECHO "::warning::Runtime specific acceptance test for platform x64 using .NET FullFramework 4.8 failed."
 )
 
-IF NOT "%ERRUNTIMEX64_net80%" == "0" (
-  SET EXITCODE=1
-  ECHO "::warning::Runtime specific acceptance test for platform x64 using .NET 6.0 failed."
-)
-
 IF NOT "%ERRUNTIMEX64_NET80%" == "0" (
   SET EXITCODE=1
   ECHO "::warning::Runtime specific acceptance test for platform x64 using .NET 8.0 failed."
@@ -102,11 +97,6 @@ IF NOT "%ERRUNTIMEX86_NET48%" == "0" (
 IF NOT "%ERRUNTIMEX86_NET80%" == "0" (
   ::SET EXITCODE=1
   ECHO "::warning::Runtime specific acceptance test for platform x86 using .NET 8.0 failed."
-)
-
-IF NOT "%ERRUNTIMEX86_net80%" == "0" (
-  ::SET EXITCODE=1
-  ECHO "::warning::Runtime specific acceptance test for platform x64 using .NET 6.0 failed."
 )
 
 IF NOT EXIST %~dp0\..\comtestdotnet\bin\x64\Release\net48\comtestdotnet.tlb (

--- a/examples/outproc/server/.vscode/launch.json
+++ b/examples/outproc/server/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/bin/Debug/net6.0-windows/dotnet6.dll",
+            "program": "${workspaceFolder}/bin/Debug/net8.0-windows/dotnet8.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/examples/outproc/server/.vscode/tasks.json
+++ b/examples/outproc/server/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/dotnet6.csproj",
+                "${workspaceFolder}/dotnet8.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -19,7 +19,7 @@
             "type": "process",
             "args": [
                 "publish",
-                "${workspaceFolder}/dotnet6.csproj",
+                "${workspaceFolder}/dotnet8.csproj",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -33,7 +33,7 @@
                 "watch",
                 "run",
                 "--project",
-                "${workspaceFolder}/dotnet6.csproj"
+                "${workspaceFolder}/dotnet8.csproj"
             ],
             "problemMatcher": "$msCompile"
         }

--- a/scripts/test.assembly.bat
+++ b/scripts/test.assembly.bat
@@ -4,7 +4,7 @@ SET workspace=%~dp0..\
 @REM set filterregex=--filterregex \.file\= --filterregex \.attributes\.guid\= --filterregex numberOfImplementedInterfaces --filterregex implementedInterfaces
 set filterregex=
 
-SET net60dll=%workspace%src\dscom.test.assembly\bin\Release\net8.0\dSPACE.Runtime.InteropServices.Test.Assembly.dll
+SET net80dll=%workspace%src\dscom.test.assembly\bin\Release\net8.0\dSPACE.Runtime.InteropServices.Test.Assembly.dll
 SET net48dll=%workspace%src\dscom.test.assembly\bin\Release\net48\dSPACE.Runtime.InteropServices.Test.Assembly.dll
 
 del %workspace%src\dscom.test.assembly\bin\Release\net48\*.tlb 
@@ -17,11 +17,11 @@ IF ERRORLEVEL 1 goto error
 
 @REM dscom
 echo ############## dscom.exe tlbexport
-%workspace%src\dscom.client\bin\Release\net8.0\dscom.exe tlbexport /verbose "%net60dll%" "/out:%net60dll%.tlb"
+%workspace%src\dscom.client\bin\Release\net8.0\dscom.exe tlbexport /verbose "%net80dll%" "/out:%net80dll%.tlb"
 IF ERRORLEVEL 1 goto error
 
 echo ############## dscom.exe tlbdump
-%workspace%src\dscom.client\bin\Release\net8.0\dscom.exe tlbdump %filterregex% "/tlbrefpath:%net60dll%.tlb/.." "%net60dll%.tlb" "/out:%net60dll%.yaml"
+%workspace%src\dscom.client\bin\Release\net8.0\dscom.exe tlbdump %filterregex% "/tlbrefpath:%net80dll%.tlb/.." "%net80dll%.tlb" "/out:%net80dll%.yaml"
 IF ERRORLEVEL 1 goto error
 
 WHERE tlbexp
@@ -56,14 +56,14 @@ IF %ERRORLEVEL% NEQ 0 (
     ECHO.
     ECHO Please compare the following files:
     ECHO %net48dll%.yaml 
-    ECHO %net60dll%.yaml
+    ECHO %net80dll%.yaml
     ECHO.
     ECHO ######################################################
     ECHO.
     goto error
 )
 
-code -d "%net48dll%.yaml" "%net60dll%.yaml"
+code -d "%net48dll%.yaml" "%net80dll%.yaml"
 
 :error
     pause

--- a/scripts/test.assembly.x86.bat
+++ b/scripts/test.assembly.x86.bat
@@ -4,7 +4,7 @@ SET workspace=%~dp0..\
 @REM set filterregex=--filterregex \.file\= --filterregex \.attributes\.guid\= --filterregex numberOfImplementedInterfaces --filterregex implementedInterfaces
 set filterregex=
 
-SET net60dll=%workspace%src\dscom.test.assembly\bin\Release\net8.0\dSPACE.Runtime.InteropServices.Test.Assembly.dll
+SET net80dll=%workspace%src\dscom.test.assembly\bin\Release\net8.0\dSPACE.Runtime.InteropServices.Test.Assembly.dll
 SET net48dll=%workspace%src\dscom.test.assembly\bin\Release\net48\dSPACE.Runtime.InteropServices.Test.Assembly.dll
 
 del %workspace%src\dscom.test.assembly\bin\Release\net48\*.tlb 
@@ -17,12 +17,12 @@ IF ERRORLEVEL 1 goto error
 
 @REM dscom
 echo ############## dscom.exe tlbexport
-dotnet run --project %workspace%src\dscom.client\dscom.client.csproj -r win-x86 -f net8.0 --no-self-contained -- tlbexport --silent "%net60dll%" "--out" "%net60dll%.tlb"
+dotnet run --project %workspace%src\dscom.client\dscom.client.csproj -r win-x86 -f net8.0 --no-self-contained -- tlbexport --silent "%net80dll%" "--out" "%net80dll%.tlb"
 
 IF ERRORLEVEL 1 goto error
 
 echo ############## dscom.exe tlbdump
-dotnet run --project %workspace%src\dscom.client\dscom.client.csproj -r win-x86 -f net8.0 --no-self-contained -- tlbdump %filterregex% "/tlbrefpath:%net60dll%.tlb/.." "%net60dll%.tlb" "/out:%net60dll%.yaml"
+dotnet run --project %workspace%src\dscom.client\dscom.client.csproj -r win-x86 -f net8.0 --no-self-contained -- tlbdump %filterregex% "/tlbrefpath:%net80dll%.tlb/.." "%net80dll%.tlb" "/out:%net80dll%.yaml"
 IF ERRORLEVEL 1 goto error
 
 WHERE tlbexp
@@ -57,14 +57,14 @@ IF %ERRORLEVEL% NEQ 0 (
     ECHO.
     ECHO Please compare the following files:
     ECHO %net48dll%.yaml 
-    ECHO %net60dll%.yaml
+    ECHO %net80dll%.yaml
     ECHO.
     ECHO ######################################################
     ECHO.
     goto error
 )
 
-code -d "%net48dll%.yaml" "%net60dll%.yaml"
+code -d "%net48dll%.yaml" "%net80dll%.yaml"
 
 :error
     pause

--- a/src/dscom.build/doc/ReadMe.md
+++ b/src/dscom.build/doc/ReadMe.md
@@ -200,7 +200,7 @@ Two targets must be executed before generating the NuSpec file:
     Hence the dependent assembly must be bundled with the NuGet package. Refer to a [blog article](https://natemcmaster.com/blog/2017/11/11/msbuild-task-with-dependencies/) for details.
 
 **DsComBuildPackTool**:
-    The MsBuild process is hosted using the target framework, i.e. .NET FullFramework 4.8 or .NET 6.0 using an x64 based process environment.
+    The MsBuild process is hosted using the target framework, i.e. .NET FullFramework 4.8 or .NET 8.0 using an x64 based process environment.
     In order to enable the build using the 32bit builder and other target frameworks, the executables will be added to the NuGet package.
     This approach has been inspired by [Grpc.Tools](https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.Tools/build/native/Grpc.Tools.props) NuGet package which bundles the `protoc.exe` and `grpc_cpp_plugin.exe` executables.
     In order to get the matching binaries without interfering with the regular MsBuild and NuGet packaging, the task calls the [MsBuild](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-task) task for the [dscom.client.csproj](/src/dscom.client/dscom.client.csproj) using the targets `Restore`, `Build` and `Pack` targets for both platforms, x86 and x64 using a different output directory.

--- a/src/dscom.build/dscom.build.csproj
+++ b/src/dscom.build/dscom.build.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <DsComBuildTargetFrameWork>net6.0</DsComBuildTargetFrameWork>
+    <DsComBuildTargetFrameWork>net8.0</DsComBuildTargetFrameWork>
     <AssemblyName>dSPACE.Runtime.InteropServices.BuildTasks</AssemblyName>
     <TargetFrameworks>net8.0;$(DsComBuildTargetFrameWork);net48</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>

--- a/src/dscom.client/dscom.client.csproj
+++ b/src/dscom.client/dscom.client.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>dscom</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Platforms>AnyCPU;x86</Platforms>
     <RuntimeIdentifiers Condition="'$(PackForBuildTaskTools)' == 'true'">win-x64;win-x86</RuntimeIdentifiers>

--- a/src/dscom.test.assembly.dependency/dscom.test.assembly.dependency.csproj
+++ b/src/dscom.test.assembly.dependency/dscom.test.assembly.dependency.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Platforms>AnyCPU;x86</Platforms>
     <RootNamespace>dSPACE.Runtime.InteropServices.Test.Assembly.Dependency</RootNamespace>

--- a/src/dscom.test.assembly/dscom.test.assembly.csproj
+++ b/src/dscom.test.assembly/dscom.test.assembly.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Platforms>AnyCPU;x86</Platforms>
     <RootNamespace>dSPACE.Runtime.InteropServices.Test.Assembly</RootNamespace>

--- a/src/dscom.test/dscom.test.csproj
+++ b/src/dscom.test/dscom.test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>dSPACE.Runtime.InteropServices.Tests</RootNamespace>
@@ -14,14 +14,17 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="moq" Version="4.20.72" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-    <PackageReference Include="xunit" Version="[2.9.3]" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="[3.0.2]" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="[17.3.0,17.4.0)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.14.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dscom.test/tests/CLITest/CompileReleaseFixture.cs
+++ b/src/dscom.test/tests/CLITest/CompileReleaseFixture.cs
@@ -42,8 +42,6 @@ public class CompileReleaseFixture
 
 #if NET8_0_OR_GREATER
         var frameworkVersion = "net8.0";
-#elif NET6_0_OR_GREATER
-        var frameworkVersion = "net6.0";
 #else
         var frameworkVersion = "net48";
 #endif

--- a/src/dscom/dscom.csproj
+++ b/src/dscom/dscom.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>dSPACE.Runtime.InteropServices</AssemblyName>
-    <TargetFrameworks>net8.0;net6.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net48</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Platforms>AnyCPU;x86</Platforms>
     <RootNamespace>dSPACE.Runtime.InteropServices</RootNamespace>


### PR DESCRIPTION
.NET 6 is end of life (12 Nov 2024)

[https://endoflife.date/dotnet](https://endoflife.date/dotnet)