### PR TITLE
fix: Validate not existing or badly formed entries in asmpath 

### DIFF
--- a/src/dscom.client/Program.cs
+++ b/src/dscom.client/Program.cs
@@ -178,6 +178,13 @@ public static class ConsoleApp
             {
                 try
                 {
+                    foreach (var asmPath in options.ASMPath)
+                    {
+                        if (!Directory.Exists(asmPath))
+                        {
+                            throw new DirectoryNotFoundException($"Directory {asmPath} not found.");
+                        }
+                    }
                     var paths = options.ASMPath.Append(Path.GetDirectoryName(options.TargetAssembly)).ToArray();
 
                     using var assemblyResolver = new AssemblyResolver(paths!, false);
@@ -279,6 +286,14 @@ public static class ConsoleApp
         var dir = Path.GetDirectoryName(options.Assembly);
 
         var asmPaths = options.ASMPath;
+        foreach (var asmPath in asmPaths)
+        {
+            if (!Directory.Exists(asmPath))
+            {
+                throw new DirectoryNotFoundException($"Directory {asmPath} not found.");
+            }
+        }
+
         if (Directory.Exists(dir))
         {
             asmPaths = asmPaths.Prepend(dir).ToArray();


### PR DESCRIPTION
Hi,
I was trying to tlbexport a Winforms UserControl and I was struggling with an error about System.Drawing.Common missing.
After I while I noticed that it was really a consequence of the --asmpath I typed that wasn't correctly identified. (i.e. --asmpath "C:\Program Files (x86)\dotnet\shared\Microsoft.WindowsDesktop.App\8.0.18\" is not correctly identified, it should be --asmpath "C:\Program Files (x86)\dotnet\shared\Microsoft.WindowsDesktop.App\8.0.18")

I added a simple Directory.Exists check that would have saved me quite some time!

PS: as changes are in dscom.client probject only, I didn't include any test as there was no test project for the console app. Just tell me if you require them.
