### PR TITLE
Regasm: should call static methods with Com(Un)RegisterFunctionAttribute

### DIFF
--- a/src/dscom.test/tests/RegistrationServicesTest.cs
+++ b/src/dscom.test/tests/RegistrationServicesTest.cs
@@ -172,15 +172,15 @@ public class RegistrationServicesTest : BaseTest
     [Fact]
     public void RegistrationServices_Should_No_ThrowOn_ComRegister_Without_Method()
     {
-        RegistrationServices.InvokeRegisterFunction(typeof(NoRegisterFunctionClass));
-        RegistrationServices.InvokeUnregisterFunction(typeof(NoRegisterFunctionClass));
+        RegistrationServices.CustomRegistrationFunction(typeof(NoRegisterFunctionClass));
+        RegistrationServices.CustomUnregistrationFunction(typeof(NoRegisterFunctionClass));
     }
 
     [Fact]
     public void RegistrationServices_Should_Invoke_ComRegisterMethod()
     {
-        RegistrationServices.InvokeRegisterFunction(typeof(SingleRegisterFunctionClass));
-        RegistrationServices.InvokeUnregisterFunction(typeof(SingleRegisterFunctionClass));
+        RegistrationServices.CustomRegistrationFunction(typeof(SingleRegisterFunctionClass));
+        RegistrationServices.CustomUnregistrationFunction(typeof(SingleRegisterFunctionClass));
 
         Assert.Equal(typeof(SingleRegisterFunctionClass), SingleRegisterFunctionClass.RegisteredType);
         Assert.Equal(typeof(SingleRegisterFunctionClass), SingleRegisterFunctionClass.UnregisteredType);
@@ -190,30 +190,30 @@ public class RegistrationServicesTest : BaseTest
     public void RegistrationServices_Should_Throw_On_Instance_ComRegisterMethod()
     {
         Assert.Throws<InvalidOperationException>(
-            () => RegistrationServices.InvokeRegisterFunction(typeof(SingleInstanceRegisterFunctionClass)));
+            () => RegistrationServices.CustomRegistrationFunction(typeof(SingleInstanceRegisterFunctionClass)));
 
         Assert.Throws<InvalidOperationException>(
-            () => RegistrationServices.InvokeUnregisterFunction(typeof(SingleInstanceRegisterFunctionClass)));
+            () => RegistrationServices.CustomUnregistrationFunction(typeof(SingleInstanceRegisterFunctionClass)));
     }
 
     [Fact]
     public void RegistrationServices_Should_Throw_On_Multiple_ComRegisterMethod()
     {
         Assert.Throws<InvalidOperationException>(
-            () => RegistrationServices.InvokeRegisterFunction(typeof(MultipleRegisterFunctionClass)));
+            () => RegistrationServices.CustomRegistrationFunction(typeof(MultipleRegisterFunctionClass)));
 
         Assert.Throws<InvalidOperationException>(
-            () => RegistrationServices.InvokeUnregisterFunction(typeof(MultipleRegisterFunctionClass)));
+            () => RegistrationServices.CustomUnregistrationFunction(typeof(MultipleRegisterFunctionClass)));
     }
 
     [Fact]
     public void RegistrationServices_Should_Throw_On_WrongSignature_ComRegisterMethod()
     {
         Assert.Throws<InvalidOperationException>(
-            () => RegistrationServices.InvokeRegisterFunction(typeof(WrongSignatureRegisterFunctionClass)));
+            () => RegistrationServices.CustomRegistrationFunction(typeof(WrongSignatureRegisterFunctionClass)));
 
         Assert.Throws<InvalidOperationException>(
-            () => RegistrationServices.InvokeUnregisterFunction(typeof(WrongSignatureRegisterFunctionClass)));
+            () => RegistrationServices.CustomUnregistrationFunction(typeof(WrongSignatureRegisterFunctionClass)));
     }
 }
 

--- a/src/dscom/RegistrationServices.cs
+++ b/src/dscom/RegistrationServices.cs
@@ -227,7 +227,7 @@ public class RegistrationServices
                 RegisterManagedType(type, fullName, assemblyVersion, codeBase, runtimeVersion, preferredAction);
             }
 
-            // Skip: CustomRegistrationFunction
+            CustomRegistrationFunction(type);
         }
 
         // Skip: PIA Regitration
@@ -263,7 +263,8 @@ public class RegistrationServices
 
         foreach (var type in typesToUnregister)
         {
-            // Skip: Custom unregister function
+            CustomUnregistrationFunction(type);
+
             if (IsComRegistratableValueType(type) && !UnregisterValueType(type, assemblyVersion))
             {
                 typesNotRemoved.Add(type);
@@ -484,8 +485,6 @@ public class RegistrationServices
         using var managedCategoryKeyForImplemented = implementedCategoryKey.CreateSubKey(RegistryKeys.ManagedCategoryGuid);
 
         SetupGlobalManagedCategoryAction(preferredAction);
-
-        InvokeRegisterFunction(type);
     }
 
     private static void SetupGlobalManagedCategoryAction(ManagedCategoryAction preferredAction)
@@ -623,8 +622,6 @@ public class RegistrationServices
 
     private static bool UnregisterManagedType(Type type, string assemblyVersion)
     {
-        InvokeUnregisterFunction(type);
-
         var clsId = $"{{{Marshal.GenerateGuidForType(type).ToString().ToUpperInvariant()}}}";
         var progId = Marshal.GenerateProgIdForType(type);
 
@@ -852,14 +849,14 @@ public class RegistrationServices
         }
     }
 
-    public static void InvokeRegisterFunction(Type type)
+    public static void CustomRegistrationFunction(Type type)
     {
         var provider = TryGetComRegisterFunction<ComRegisterFunctionAttribute>(type);
 
         provider?.Invoke(null, new object[] { type });
     }
 
-    public static void InvokeUnregisterFunction(Type type)
+    public static void CustomUnregistrationFunction(Type type)
     {
         var provider = TryGetComRegisterFunction<ComUnregisterFunctionAttribute>(type);
 


### PR DESCRIPTION
The former regasm-tool got the feature, that it calls static methods with the ComRegisterFunctionAttribute and ComUnregisterFunctionAttribute.

I added the feature, so that you can add additional steps for registration.

In my case i will add further RegistryKeys for an ActiveX-Component.

[https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.comregisterfunctionattribute?view=net-9.0](Attribute