### PR TITLE
fix: Update enum handling to use underlying types

### DIFF
--- a/src/dscom.test/tests/EnumTest.cs
+++ b/src/dscom.test/tests/EnumTest.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.ComponentModel;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -44,9 +45,44 @@ public class EnumTest : BaseTest
 
         var kv = typeLibInfo!.GetAllEnumValues();
 
-        Assert.Contains(new KeyValuePair<string, object>("TestEnum_A", 1), kv);
-        Assert.Contains(new KeyValuePair<string, object>("TestEnum_B", 20), kv);
-        Assert.Contains(new KeyValuePair<string, object>("TestEnum_C", 50), kv);
+        Assert.Contains(new KeyValuePair<string, object>("TestEnum_A", Convert.ChangeType(1, type, CultureInfo.InvariantCulture)!), kv);
+        Assert.Contains(new KeyValuePair<string, object>("TestEnum_B", Convert.ChangeType(20, type, CultureInfo.InvariantCulture)!), kv);
+        Assert.Contains(new KeyValuePair<string, object>("TestEnum_C", Convert.ChangeType(50, type, CultureInfo.InvariantCulture)!), kv);
+    }
+
+    [Theory]
+    [InlineData(typeof(byte))]
+    [InlineData(typeof(sbyte))]
+    [InlineData(typeof(short))]
+    [InlineData(typeof(ushort))]
+    [InlineData(typeof(uint))]
+    [InlineData(typeof(int))]
+    [InlineData(typeof(ulong))]
+    [InlineData(typeof(long))]
+    public void EnumWithNumericValues_UsesUnderlyingTypeForExportedMetadata(Type type)
+    {
+        var result = CreateAssembly(CreateAssemblyName(assemblyNameSuffix: $"{type}"))
+            .WithEnum("TestEnum", type)
+                .WithLiteral("A", 1)
+                .Build()
+            .Build();
+
+        var typeLibInfo = result.TypeLib.GetTypeInfoByName("TestEnum");
+        Assert.NotNull(typeLibInfo);
+
+        typeLibInfo!.GetVarDesc(0, out var ppVarDesc);
+        try
+        {
+            var varDesc = Marshal.PtrToStructure<VARDESC>(ppVarDesc);
+            var enumValue = typeLibInfo.GetAllEnumValues().Single(kv => kv.Key == "TestEnum_A").Value;
+
+            Assert.Equal(type.GetShortVarEnum(), varDesc.elemdescVar.tdesc.vt);
+            Assert.Equal(type, enumValue.GetType());
+        }
+        finally
+        {
+            typeLibInfo.ReleaseVarDesc(ppVarDesc);
+        }
     }
 
     [Fact]

--- a/src/dscom/writer/EnumWriter.cs
+++ b/src/dscom/writer/EnumWriter.cs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 using System.ComponentModel;
-using System.Globalization;
 using System.Reflection;
-using System.Runtime.InteropServices;
 
 namespace dSPACE.Runtime.InteropServices.Writer;
 
@@ -31,25 +29,22 @@ internal sealed class EnumWriter : TypeWriter
         ((ITypeInfo)TypeInfo).GetDocumentation(-1, out var name, out var docString, out var helpContext, out var helpFile);
 
         uint index = 0;
+        var enumUnderlyingType = SourceType.GetEnumUnderlyingType();
+        var enumVariantType = new TypeProvider(Context, SourceType, isMethod: false).GetVariantType(enumUnderlyingType, out _);
         var fields =
             SourceType.GetFields(BindingFlags.Public | BindingFlags.Static)
             .OrderBy(field => field.MetadataToken);
         foreach (var field in fields)
         {
             var varDesc = new VARDESC();
-            var varDescSymbConst = new VARIANT();
+            var enumValue = field.GetRawConstantValue();
 
-            var enumValue = Enum.Parse(SourceType, field.Name.ToString());
-            var enumLongValue = (long)Convert.ChangeType(enumValue, typeof(long), CultureInfo.InvariantCulture);
-            varDescSymbConst.byref = new IntPtr(enumLongValue);
-            varDescSymbConst.vt = VarEnum.VT_I4;
-
-            varDesc.desc.lpvarValue = StructureToPtr(varDescSymbConst);
+            varDesc.desc.lpvarValue = ObjectToVariantPtr(enumValue);
             varDesc.elemdescVar.desc.idldesc.dwReserved = IntPtr.Zero;
             varDesc.elemdescVar.desc.idldesc.wIDLFlags = IDLFLAG.IDLFLAG_NONE;
             varDesc.elemdescVar.desc.paramdesc.lpVarValue = IntPtr.Zero;
             varDesc.elemdescVar.desc.paramdesc.wParamFlags = PARAMFLAG.PARAMFLAG_NONE;
-            varDesc.elemdescVar.tdesc.vt = (short)VarEnum.VT_I4;
+            varDesc.elemdescVar.tdesc.vt = (short)enumVariantType;
             varDesc.lpstrSchema = null!;
             varDesc.memid = -1;
             varDesc.varkind = VARKIND.VAR_CONST;


### PR DESCRIPTION
When exporting enums into the generated type library, enum types were effectively always treated as `VT_I4`. As a result, both the type metadata of the enum field and the stored constant value were not aligned with the enum's actual underlying CLR type.

The root cause was in `src/dscom/writer/EnumWriter.cs`.

Before the fix, two places were hardcoded to `VT_I4`:

- the `VARDESC` type description of the enum entry
- the native variant value for the enum constant

This caused information about underlying types such as `byte`, `sbyte`, `short`, `ushort`, `uint`, `long`, and `ulong` to be lost.
