### PR TITLE
fix: file quoting in Delete target for touch file handling

### DIFF
--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
@@ -186,8 +186,7 @@
           WorkingDirectory="$(_DsComWorkingDir)" 
           Condition="Exists('$(_DsComRegistrationTouchFile)')" />
     <!-- Workaround: Instead of asking whether the TLB is registered using the registry, we rely on a touch file. -->
-    <Delete Files="'$(_DsComRegistrationTouchFile)'"
+    <Delete Files="$(_DsComRegistrationTouchFile)"
             Condition="Exists('$(_DsComRegistrationTouchFile)')" />
   </Target>
 </Project>
-


### PR DESCRIPTION
In MSBuild, single quotes inside an attribute value are treated as literal characters and become part of the file path. The `Delete` task therefore attempts to delete a file whose name starts and ends with `'`, which does not exist. The task silently succeeds (no error is raised) but the real touch file is **never deleted**.

Compare with the `Touch` task in the same file, which correctly has no extra quotes:

```xml
<Touch AlwaysCreate="true" Files="$(_DsComRegistrationTouchFile)" ForceTouch="false" />
```

## Fix

Remove the extraneous single quotes from the `Files` attribute of the `Delete` task in `dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets`:

```xml
<Delete Files="$(_DsComRegistrationTouchFile)"
        Condition="Exists('$(_DsComRegistrationTouchFile)')" />
```

This makes the `Delete` task target the actual touch file path, ensuring the guard is properly reset after each unregistration and `tlbunregister` is never called against a TLB that is no longer in the registry.