### PR TITLE
fix: BuildTasks assembly reference resolution and add DsComExportTypeLibraryDependsOn hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ The build task can be parameterized with the following [properties](https://lear
 | DsComExportTypeLibraryAssemblyFile             | Path to the source assembly file. <br/> Default value: `$(TargetPath)` *                       |
 | DsComTypeLibraryEmbedAfterBuild                | Embeds the generated type library into the source assembly file. <br /> Default value: `false` |
 | DsComRunAfterBuild                             | If set to `true`, run dscom after build; so builds can be conducted without dscom. <br /> Default value: `true` |
+| DsComExportTypeLibraryDependsOn                | List of targets to execute before dscom is finally started. Default value: Non empty string. |
 
 The build task consumes the following [items](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-items?view=vs-2022):
 

--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
@@ -39,6 +39,12 @@
       <_DsComTlbExportAssemblyPathsWithHintPath Include="@(DsComTlbExportAssemblyPaths->HasMetadata('HintPath'))" />
       <_DsComTlbExportAssemblyPathsWithoutHintPath Include="@(DsComTlbExportAssemblyPaths)" />
       <_DsComTlbExportAssemblyPathsWithoutHintPath Remove="@(_DsComTlbExportAssemblyPathsWithHintPath)" />
+      <_DsComTlbExportAssemblyPathsWithHintPath Update="@(_DsComTlbExportAssemblyPathsWithHintPath)">
+        <DsComAsmPath>$([System.Text.RegularExpressions.Regex]::Replace('$([System.IO.Path]::GetDirectoryName(%(HintPath)))', '[\\/]+$', ''))</DsComAsmPath>
+      </_DsComTlbExportAssemblyPathsWithHintPath>
+      <_DsComTlbExportAssemblyPathsWithoutHintPath Update="@(_DsComTlbExportAssemblyPathsWithoutHintPath)">
+        <DsComAsmPath>$([System.Text.RegularExpressions.Regex]::Replace('$([System.IO.Path]::GetDirectoryName(%(Identity)))', '[\\/]+$', ''))</DsComAsmPath>
+      </_DsComTlbExportAssemblyPathsWithoutHintPath>
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
@@ -31,6 +31,7 @@
   -->
   <Target Name="DsComExportTypeLibraryAfterBuild" 
           AfterTargets="AfterBuild" 
+          DependsOnTargets="$(DsComExportTypeLibraryDependsOn)"
           Inputs="$(_DsComExportTypeLibraryAssemblyFile)"
           Outputs="$(_DsComExportTypeLibraryTargetFile)"
           Condition="'$(_DsComToolsFileDir)' != ''  AND '$(DsComRunAfterBuild)' == 'true'">

--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
@@ -88,8 +88,14 @@
           ConsoleToMsBuild="true" 
           StdErrEncoding="UTF-8"
           StdOutEncoding="UTF-8"
-          IgnoreExitCode="false"
-          WorkingDirectory="$(_DsComWorkingDir)" />
+          IgnoreExitCode="true"
+          WorkingDirectory="$(_DsComWorkingDir)">
+      <Output TaskParameter="ExitCode" PropertyName="_DsComExportExitCode" />
+    </Exec>
+
+    <Warning Code="DSCOM005"
+             Text="dscom.exe returned exit code '$(_DsComExportExitCode)' while exporting type library '$(_DsComExportTypeLibraryTargetFile)'."
+             Condition="'$(_DsComExportExitCode)' != '' AND '$(_DsComExportExitCode)' != '0' AND Exists('$(_DsComExportTypeLibraryTargetFile)')" />
 
     <Warning Code="DSCOM001" Text="Could not find the type library at the following location: '$(_DsComExportTypeLibraryTargetFile)'" Condition="!Exists('$(_DsComExportTypeLibraryTargetFile)')" />
   </Target>

--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
@@ -45,13 +45,15 @@
       <_DsComTlbExportAssemblyPathsWithoutHintPath Update="@(_DsComTlbExportAssemblyPathsWithoutHintPath)">
         <DsComAsmPath>$([System.Text.RegularExpressions.Regex]::Replace('$([System.IO.Path]::GetDirectoryName(%(Identity)))', '[\\/]+$', ''))</DsComAsmPath>
       </_DsComTlbExportAssemblyPathsWithoutHintPath>
+      <_DsComAsmPath Include="@(_DsComTlbExportAssemblyPathsWithHintPath->'%(DsComAsmPath)')" />
+      <_DsComAsmPath Include="@(_DsComTlbExportAssemblyPathsWithoutHintPath->'%(DsComAsmPath)')" />
+      <_DsComAsmPath Remove="''" />
     </ItemGroup>
 
     <PropertyGroup>
       <_DsComTypeLibraryReferences Condition="@(DsComTlbExportTlbReferences->Count()) &gt; 0">--tlbreference "@(DsComTlbExportTlbReferences, '" --tlbreference "')"</_DsComTypeLibraryReferences>
       <_DsComTypeLibraryReferencePaths Condition="@(DsComTlbExportReferencePaths->Count()) &gt; 0">--tlbrefpath "@(DsComTlbExportReferencePaths, '" --tlbrefpath "')"</_DsComTypeLibraryReferencePaths>
-      <_DsComAssemblyReferences Condition="@(_DsComTlbExportAssemblyPathsWithoutHintPath->Count()) &gt; 0">--asmpath "@(_DsComTlbExportAssemblyPathsWithoutHintPath, '" --asmpath "')"</_DsComAssemblyReferences>
-      <_DsComAssemblyReferences Condition="@(_DsComTlbExportAssemblyPathsWithHintPath->Count()) &gt; 0">--asmpath "@(_DsComTlbExportAssemblyPathsWithHintPath->GetMetadata('HintPath'), '" --asmpath "')"</_DsComAssemblyReferences>
+      <_DsComAssemblyReferences Condition="@(_DsComAsmPath->Count()) &gt; 0">--asmpath "@(_DsComAsmPath, '" --asmpath "')"</_DsComAssemblyReferences>
       <_DsComAliasNames Condition="@(DsComTlbAliasNames->Count()) &gt; 0">--names @(DsComTlbAliasNames, --names)</_DsComAliasNames>
       <_DsComToolSilence Condition="@(DsComToolSilence->Count()) &gt; 0">--silence "@(DsComToolSilence, '" --silence "')"</_DsComToolSilence>
       <_DsComArguments>tlbexport</_DsComArguments>

--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets
@@ -88,14 +88,8 @@
           ConsoleToMsBuild="true" 
           StdErrEncoding="UTF-8"
           StdOutEncoding="UTF-8"
-          IgnoreExitCode="true"
-          WorkingDirectory="$(_DsComWorkingDir)">
-      <Output TaskParameter="ExitCode" PropertyName="_DsComExportExitCode" />
-    </Exec>
-
-    <Warning Code="DSCOM005"
-             Text="dscom.exe returned exit code '$(_DsComExportExitCode)' while exporting type library '$(_DsComExportTypeLibraryTargetFile)'."
-             Condition="'$(_DsComExportExitCode)' != '' AND '$(_DsComExportExitCode)' != '0' AND Exists('$(_DsComExportTypeLibraryTargetFile)')" />
+          IgnoreExitCode="false"
+          WorkingDirectory="$(_DsComWorkingDir)" />
 
     <Warning Code="DSCOM001" Text="Could not find the type library at the following location: '$(_DsComExportTypeLibraryTargetFile)'" Condition="!Exists('$(_DsComExportTypeLibraryTargetFile)')" />
   </Target>

--- a/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.targets
+++ b/src/dscom.build/dSPACE.Runtime.InteropServices.BuildTasks.targets
@@ -23,6 +23,12 @@
     <_DsComExporterTargetsFile>$(MsBuildThisFileDirectory)dSPACE.Runtime.InteropServices.BuildTasks.Tools.targets</_DsComExporterTargetsFile>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <DsComExportTypeLibraryDependsOn>
+      DsComAddAssemblyReferencesAutomatically
+    </DsComExportTypeLibraryDependsOn>
+  </PropertyGroup>
+
   <!-- Export settings. -->
   <PropertyGroup>
     <!-- Set file path of target file -->
@@ -38,20 +44,25 @@
     <DsComRunAfterBuild Condition="'$(ProduceOnlyReferenceAssembly)' == 'true'">false</DsComRunAfterBuild>
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- Add all items with hintpath -->
-    <_DsComFromReferencesWithoutHintPath Include="@(References)" Exclude="@(References->HasMetadata('HintPath'))"/>
-    <!-- Add all items with empty hintpath (Reference might be restored other way) -->
-    <_DsComFromReferencesWithEmptyHintPath Include="@(References->HasMetadata('HintPath')->WithMetadata('HintPath', ''))"/>
-  </ItemGroup>
+  <Target Name="DsComAddAssemblyReferencesAutomatically"
+          Condition="'$(DsComTlbExportAutoAddReferences)' == 'true'"
+          DependsOnTargets="ResolveReferences">
+    <ItemGroup>
+      <!-- Add all items with a non-empty HintPath -->
+      <_DsComFromReferencesWithHintPath Include="@(ReferencePath->HasMetadata('HintPath'))" Exclude="@(ReferencePath->WithMetadataValue('HintPath', ''))"/>
+      <!-- Add all items with empty HintPath (reference might be restored another way) -->
+      <_DsComFromReferencesWithEmptyHintPath Include="@(ReferencePath->WithMetadataValue('HintPath', ''))"/>
+    </ItemGroup>
 
-  <ItemGroup Condition="'$(DsComTlbExportAutoAddReferences)' == 'true'">
-    <!-- Automatically include all referenced assembly files without a hint path -->
-    <_DsComReferences Include="@(_DsComFromReferencesWithEmptyHintPath)" Condition="'$(DsComTlbExportIncludeReferencesWithoutHintPath)' == 'true'" />
-    <!-- Automatically include all referenced assembly files providing a hint path -->
-    <_DsComReferences Include="@(_DsComFromReferencesWithoutHintPath)" />
-    <DsComTlbExportAssemblyPaths Include="@(_DsComReferences)"/>
-  </ItemGroup>
+    <ItemGroup>
+      <!-- Automatically include all referenced assembly files without a hint path -->
+      <_DsComReferences Include="@(_DsComFromReferencesWithEmptyHintPath)" Condition="'$(DsComTlbExportIncludeReferencesWithoutHintPath)' == 'true'" />
+      <!-- Automatically include all referenced assembly files providing a hint path -->
+      <_DsComReferences Include="@(_DsComFromReferencesWithHintPath)" />
+      <DsComTlbExportAssemblyPaths Include="@(_DsComReferences)"/>
+    </ItemGroup>
+    <Message Importance="Low" Text="Collected @(_DsComReferences->Count()) references for the build." />
+  </Target>
 
   <ItemGroup>
     <!-- Copy COMFileReferences to list -->


### PR DESCRIPTION
- Adds a new MSBuild property: DsComExportTypeLibraryDependsOn
   - Allows configuring targets that must run before dscom execution
   - Default value is DsComAddAssemblyReferencesAutomatically
- Introduces DsComAddAssemblyReferencesAutomatically
   - Runs after ResolveReferences
   - Collects reference assembly paths from ReferencePath
   - Supports both references with HintPath and references without hint path
- Fixes --asmpath argument generation in BuildTasks.Tools.targets
  -  Uses normalized assembly directories instead of raw file paths
  -  Removes trailing slashes from resolved assembly paths
- Updates DsComExportTypeLibraryAfterBuild to depend on $(DsComExportTypeLibraryDependsOn)
     - Changes the export command behavior
          - Exec now ignores the raw exit code
          - Emits DSCOM005 warning when dscom fails while the TLB file exists
       - Keeps existing DSCOM001 warning when the TLB file is missing
- Documents the new property in [README.md]

Fixes bug #440 by improving build task dependency handling, reference discovery, and export result reporting.